### PR TITLE
Use tire.index.name instead of index_name, as user could be using a proc (tire already handles that)

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -41,7 +41,7 @@ module Searchkick
     # remove old indices that start w/ index_name
     def clean_indices
       all_indices = JSON.parse(Tire::Configuration.client.get("#{Tire::Configuration.url}/_aliases").body)
-      indices = all_indices.select{|k, v| v["aliases"].empty? && k =~ /\A#{Regexp.escape(index_name)}_\d{14,17}\z/ }.keys
+      indices = all_indices.select{|k, v| v["aliases"].empty? && k =~ /\A#{Regexp.escape(tire.index.name)}_\d{14,17}\z/ }.keys
       indices.each do |index|
         Tire::Index.new(index).delete
       end


### PR DESCRIPTION
I was trying to implement dynamic index names with Searchkick today (for a multi-tenanted app) and ran into this slight bug. Tire already supports having the index_name as a Proc, but there was this part of the code that used index_name over tire.index.name. Doing so will crash if the index_name is indeed a proc. Thanks!
