### PR TITLE
added possibility to filter terms with execution: and option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ where: {
   expires_at: {gt: Time.now}, # lt, gte, lte also available
   orders_count: 1..10,        # equivalent to {gte: 1, lte: 10}
   aisle_id: [25, 30],         # in
+  aisle_id: {and: [1,3]}      # and
   store_id: {not: 2},         # not
   aisle_id: {not: [25, 30]},  # not in
   or: [

--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -201,6 +201,8 @@ module Searchkick
                     else
                       filters << {not: {term: {field => op_value}}}
                     end
+                  elsif op == :and
+                    filters << {terms: {field => op_value, execution: 'and'}}
                   else
                     range_query =
                       case op

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -39,7 +39,7 @@ class TestSql < Minitest::Unit::TestCase
     now = Time.now
     store [
       {name: "Product A", store_id: 1, in_stock: true, backordered: true, created_at: now, orders_count: 4, user_ids: [1, 2, 3]},
-      {name: "Product B", store_id: 2, in_stock: true, backordered: false, created_at: now - 1, orders_count: 3},
+      {name: "Product B", store_id: 2, in_stock: true, backordered: false, created_at: now - 1, orders_count: 3, user_ids: [1]},
       {name: "Product C", store_id: 3, in_stock: false, backordered: true, created_at: now - 2, orders_count: 2},
       {name: "Product D", store_id: 4, in_stock: false, backordered: false, created_at: now - 3, orders_count: 1},
     ]
@@ -65,6 +65,8 @@ class TestSql < Minitest::Unit::TestCase
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{orders_count: [2, 4]}, {store_id: [1, 2]}]]}
     assert_search "product", ["Product A", "Product D"], where: {or: [[{orders_count: 1}, {created_at: {gte: now - 1}, backordered: true}]]}
     # array
+    assert_search "product", ["Product A"], where: {user_ids: { and: [1,3]}}
+    assert_search "product", [], where: { where_ids: { and: [1,2,3,4] } }
     assert_search "product", ["Product A"], where: {user_ids: 2}
   end
 


### PR DESCRIPTION
let's say i have a many-to-many relationship between `Project` and `Category` models.

i defined  `Project` Model like this in order to get categories_title:

``` ruby
class Project < ActiveRecord::Base
  def search_data
    attributes.merge(
      categories_id: categories.map(&:title)
     )
  end
end
```

so in controller:

``` ruby
 @project_search = Project.search 'house', where: { categories_title: ['farm'] } 
```

results in view:

``` ruby
 # sidebar 
 farm (3)
 house (1)
 apartment(2)
```

when i click in `house` i expected just one **project result**, but it returned 4.

i'm not very sure if i fit to your code conventions, but i fixed this way when i'm doing this kind of search:

``` ruby
 @project_search = Project.search 'house', where: { categories_title: { and: ['farm', 'house'] } }
```

and it returned just one project as i expected.
