### PR TITLE
Update similar.rb

### DIFF
--- a/lib/searchkick/similar.rb
+++ b/lib/searchkick/similar.rb
@@ -9,7 +9,7 @@ module Searchkick
       # TODO deep merge method
       options[:where] ||= {}
       options[:where][:_id] ||= {}
-      options[:where][:_id][:not] = id
+      options[:where][:_id][:not] = id.to_s
       options[:limit] ||= 10
       options[:similar] = true
       self.class.search(like_text, options)


### PR DESCRIPTION
Without it `#similar` method for Mongoid throw error

```
filter does not support [$oid]];
```

because id is a hash {'$oid' : XXX}
