### PR TITLE
Add custom mappings and settings to defaults instead of replacing them

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -82,181 +82,174 @@ module Searchkick
     def searchkick_index_options
       options = searchkick_options
 
-      if options[:mappings]
-        settings = options[:settings] || {}
-        mappings = options[:mappings]
-      else
-        settings = {
-          analysis: {
-            analyzer: {
-              searchkick_keyword: {
-                type: "custom",
-                tokenizer: "keyword",
-                filter: ["lowercase", "snowball"]
-              },
-              default_index: {
-                type: "custom",
-                tokenizer: "standard",
-                # synonym should come last, after stemming and shingle
-                # shingle must come before snowball
-                filter: ["standard", "lowercase", "asciifolding", "stop", "searchkick_index_shingle", "snowball"]
-              },
-              searchkick_search: {
-                type: "custom",
-                tokenizer: "standard",
-                filter: ["standard", "lowercase", "asciifolding", "stop", "searchkick_search_shingle", "snowball"]
-              },
-              searchkick_search2: {
-                type: "custom",
-                tokenizer: "standard",
-                filter: ["standard", "lowercase", "asciifolding", "stop", "snowball"]
-              },
-              # https://github.com/leschenko/elasticsearch_autocomplete/blob/master/lib/elasticsearch_autocomplete/analyzers.rb
-              searchkick_autocomplete_index: {
-                type: "custom",
-                tokenizer: "searchkick_autocomplete_ngram",
-                filter: ["lowercase", "asciifolding"]
-              },
-              searchkick_autocomplete_search: {
-                type: "custom",
-                tokenizer: "keyword",
-                filter: ["lowercase", "asciifolding"]
-              },
-              searchkick_suggest_index: {
-                type: "custom",
-                tokenizer: "standard",
-                filter: ["lowercase", "asciifolding", "searchkick_suggest_shingle"]
-              }
+      settings = {
+        analysis: {
+          analyzer: {
+            searchkick_keyword: {
+              type: "custom",
+              tokenizer: "keyword",
+              filter: ["lowercase", "snowball"]
             },
-            filter: {
-              searchkick_index_shingle: {
-                type: "shingle",
-                token_separator: ""
-              },
-              # lucky find http://web.archiveorange.com/archive/v/AAfXfQ17f57FcRINsof7
-              searchkick_search_shingle: {
-                type: "shingle",
-                token_separator: "",
-                output_unigrams: false,
-                output_unigrams_if_no_shingles: true
-              },
-              searchkick_suggest_shingle: {
-                type: "shingle",
-                max_shingle_size: 5
-              }
+            default_index: {
+              type: "custom",
+              tokenizer: "standard",
+              # synonym should come last, after stemming and shingle
+              # shingle must come before snowball
+              filter: ["standard", "lowercase", "asciifolding", "stop", "searchkick_index_shingle", "snowball"]
             },
-            tokenizer: {
-              searchkick_autocomplete_ngram: {
-                type: "edgeNGram",
-                min_gram: 1,
-                max_gram: 50
-              }
+            searchkick_search: {
+              type: "custom",
+              tokenizer: "standard",
+              filter: ["standard", "lowercase", "asciifolding", "stop", "searchkick_search_shingle", "snowball"]
+            },
+            searchkick_search2: {
+              type: "custom",
+              tokenizer: "standard",
+              filter: ["standard", "lowercase", "asciifolding", "stop", "snowball"]
+            },
+            # https://github.com/leschenko/elasticsearch_autocomplete/blob/master/lib/elasticsearch_autocomplete/analyzers.rb
+            searchkick_autocomplete_index: {
+              type: "custom",
+              tokenizer: "searchkick_autocomplete_ngram",
+              filter: ["lowercase", "asciifolding"]
+            },
+            searchkick_autocomplete_search: {
+              type: "custom",
+              tokenizer: "keyword",
+              filter: ["lowercase", "asciifolding"]
+            },
+            searchkick_suggest_index: {
+              type: "custom",
+              tokenizer: "standard",
+              filter: ["lowercase", "asciifolding", "searchkick_suggest_shingle"]
+            }
+          },
+          filter: {
+            searchkick_index_shingle: {
+              type: "shingle",
+              token_separator: ""
+            },
+            # lucky find http://web.archiveorange.com/archive/v/AAfXfQ17f57FcRINsof7
+            searchkick_search_shingle: {
+              type: "shingle",
+              token_separator: "",
+              output_unigrams: false,
+              output_unigrams_if_no_shingles: true
+            },
+            searchkick_suggest_shingle: {
+              type: "shingle",
+              max_shingle_size: 5
+            }
+          },
+          tokenizer: {
+            searchkick_autocomplete_ngram: {
+              type: "edgeNGram",
+              min_gram: 1,
+              max_gram: 50
             }
           }
         }
+      }.deep_merge(options[:settings] || {})
 
-        if searchkick_env == "test"
-          settings.merge!(number_of_shards: 1, number_of_replicas: 0)
+      if searchkick_env == "test"
+        settings.merge!(number_of_shards: 1, number_of_replicas: 0)
+      end
+
+      # synonyms
+      synonyms = options[:synonyms] || []
+      if synonyms.any?
+        settings[:analysis][:filter][:searchkick_synonym] = {
+          type: "synonym",
+          synonyms: synonyms.select{|s| s.size > 1 }.map{|s| s.join(",") }
+        }
+        # choosing a place for the synonym filter when stemming is not easy
+        # https://groups.google.com/forum/#!topic/elasticsearch/p7qcQlgHdB8
+        # TODO use a snowball stemmer on synonyms when creating the token filter
+
+        # http://elasticsearch-users.115913.n3.nabble.com/synonym-multi-words-search-td4030811.html
+        # I find the following approach effective if you are doing multi-word synonyms (synonym phrases):
+        # - Only apply the synonym expansion at index time
+        # - Don't have the synonym filter applied search
+        # - Use directional synonyms where appropriate. You want to make sure that you're not injecting terms that are too general.
+        settings[:analysis][:analyzer][:default_index][:filter].insert(4, "searchkick_synonym")
+        settings[:analysis][:analyzer][:default_index][:filter] << "searchkick_synonym"
+      end
+
+      if options[:special_characters] == false
+        settings[:analysis][:analyzer].each do |analyzer, analyzer_settings|
+          analyzer_settings[:filter].reject!{|f| f == "asciifolding" }
         end
+      end
 
-        settings.merge!(options[:settings] || {})
+      mapping = {}
 
-        # synonyms
-        synonyms = options[:synonyms] || []
-        if synonyms.any?
-          settings[:analysis][:filter][:searchkick_synonym] = {
-            type: "synonym",
-            synonyms: synonyms.select{|s| s.size > 1 }.map{|s| s.join(",") }
-          }
-          # choosing a place for the synonym filter when stemming is not easy
-          # https://groups.google.com/forum/#!topic/elasticsearch/p7qcQlgHdB8
-          # TODO use a snowball stemmer on synonyms when creating the token filter
-
-          # http://elasticsearch-users.115913.n3.nabble.com/synonym-multi-words-search-td4030811.html
-          # I find the following approach effective if you are doing multi-word synonyms (synonym phrases):
-          # - Only apply the synonym expansion at index time
-          # - Don't have the synonym filter applied search
-          # - Use directional synonyms where appropriate. You want to make sure that you're not injecting terms that are too general.
-          settings[:analysis][:analyzer][:default_index][:filter].insert(4, "searchkick_synonym")
-          settings[:analysis][:analyzer][:default_index][:filter] << "searchkick_synonym"
-        end
-
-        if options[:special_characters] == false
-          settings[:analysis][:analyzer].each do |analyzer, analyzer_settings|
-            analyzer_settings[:filter].reject!{|f| f == "asciifolding" }
-          end
-        end
-
-        mapping = {}
-
-        # conversions
-        if options[:conversions]
-          mapping[:conversions] = {
-            type: "nested",
-            properties: {
-              query: {type: "string", analyzer: "searchkick_keyword"},
-              count: {type: "integer"}
-            }
-          }
-        end
-
-        # autocomplete and suggest
-        autocomplete = (options[:autocomplete] || []).map(&:to_s)
-        suggest = (options[:suggest] || []).map(&:to_s)
-        (autocomplete + suggest).uniq.each do |field|
-          field_mapping = {
-            type: "multi_field",
-            fields: {
-              field => {type: "string", index: "not_analyzed"},
-              "analyzed" => {type: "string", index: "analyzed"}
-              # term_vector: "with_positions_offsets" for fast / correct highlighting
-              # http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_fast_vector_highlighter
-            }
-          }
-          if autocomplete.include?(field)
-            field_mapping[:fields]["autocomplete"] = {type: "string", index: "analyzed", analyzer: "searchkick_autocomplete_index"}
-          end
-          if suggest.include?(field)
-            field_mapping[:fields]["suggest"] = {type: "string", index: "analyzed", analyzer: "searchkick_suggest_index"}
-          end
-          mapping[field] = field_mapping
-        end
-
-        (options[:locations] || []).each do |field|
-          mapping[field] = {
-            type: "geo_point"
-          }
-        end
-
-        mappings = {
-          _default_: {
-            properties: mapping,
-            # https://gist.github.com/kimchy/2898285
-            dynamic_templates: [
-              {
-                string_template: {
-                  match: "*",
-                  match_mapping_type: "string",
-                  mapping: {
-                    # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
-                    type: "multi_field",
-                    fields: {
-                      # analyzed field must be the default field for include_in_all
-                      # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
-                      # however, we can include the not_analyzed field in _all
-                      # and the _all index analyzer will take care of it
-                      "{name}" => {type: "string", index: "not_analyzed"},
-                      "analyzed" => {type: "string", index: "analyzed"}
-                    }
-                  }
-                }
-              }
-            ]
+      # conversions
+      if options[:conversions]
+        mapping[:conversions] = {
+          type: "nested",
+          properties: {
+            query: {type: "string", analyzer: "searchkick_keyword"},
+            count: {type: "integer"}
           }
         }
       end
 
-      {
+      # autocomplete and suggest
+      autocomplete = (options[:autocomplete] || []).map(&:to_s)
+      suggest = (options[:suggest] || []).map(&:to_s)
+      (autocomplete + suggest).uniq.each do |field|
+        field_mapping = {
+          type: "multi_field",
+          fields: {
+            field => {type: "string", index: "not_analyzed"},
+            "analyzed" => {type: "string", index: "analyzed"}
+            # term_vector: "with_positions_offsets" for fast / correct highlighting
+            # http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_fast_vector_highlighter
+          }
+        }
+        if autocomplete.include?(field)
+          field_mapping[:fields]["autocomplete"] = {type: "string", index: "analyzed", analyzer: "searchkick_autocomplete_index"}
+        end
+        if suggest.include?(field)
+          field_mapping[:fields]["suggest"] = {type: "string", index: "analyzed", analyzer: "searchkick_suggest_index"}
+        end
+        mapping[field] = field_mapping
+      end
+
+      (options[:locations] || []).each do |field|
+        mapping[field] = {
+          type: "geo_point"
+        }
+      end
+
+      mappings = {
+        _default_: {
+          properties: mapping,
+          # https://gist.github.com/kimchy/2898285
+          dynamic_templates: [
+            {
+              string_template: {
+                match: "*",
+                match_mapping_type: "string",
+                mapping: {
+                  # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
+                  type: "multi_field",
+                  fields: {
+                    # analyzed field must be the default field for include_in_all
+                    # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
+                    # however, we can include the not_analyzed field in _all
+                    # and the _all index analyzer will take care of it
+                    "{name}" => {type: "string", index: "not_analyzed"},
+                    "analyzed" => {type: "string", index: "analyzed"}
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }.deep_merge(options[:mappings] || {})
+
+      return {
         settings: settings,
         mappings: mappings
       }

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -32,4 +32,9 @@ class TestIndex < Minitest::Unit::TestCase
     assert_equal ["Dollar Tree"], Store.search(query: {match: {name: "Dollar Tree"}}).map(&:name)
   end
 
+  def test_custom_mapping_does_not_override_defaults
+    store_names ["Dollar Tree"], Store
+    assert_equal ["Dollar Tree"], Store.search("dllrtr").map(&:name)
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,15 @@ if defined?(Mongoid)
     include Mongoid::Document
 
     field :name
+    field :code
+
+    before_save :set_code
+
+    private
+
+    def set_code
+      self.code = name.gsub(/[aeiou\W]/, '').downcase
+    end
   end
 
   class Animal
@@ -85,6 +94,7 @@ else
 
   ActiveRecord::Migration.create_table :stores, :force => true do |t|
     t.string :name
+    t.string :code
   end
 
   ActiveRecord::Migration.create_table :animals, :force => true do |t|
@@ -96,6 +106,13 @@ else
   end
 
   class Store < ActiveRecord::Base
+    before_save :set_code
+
+    private
+
+    def set_code
+      self.code = name.gsub(/[aeiou\W]/, '').downcase
+    end
   end
 
   class Animal < ActiveRecord::Base
@@ -162,6 +179,7 @@ class Minitest::Unit::TestCase
 
   def setup
     Product.destroy_all
+    Store.destroy_all
     Animal.destroy_all
   end
 


### PR DESCRIPTION
I needed to define a custom analyzer for one of my indexes along with a custom mapping for one field to use that analyzer. However, I didn't want to replace the default settings and mappings provided by Searchkick (because they're a pretty great set of defaults).

This change modifies the indexing behavior so that custom-defined mappings and settings are _added to_ the default set instead of replacing them outright. I realize that this may be a breaking change but felt that it was important for anyone doing extensive customization -- or at least for us, anyway!

Thoughts / discussion welcome.

See https://github.com/ankane/searchkick/issues/99 for the original issue.
