### PR TITLE
Changing only a portion of the settings

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -159,7 +159,7 @@ module Searchkick
           settings.merge!(number_of_shards: 1, number_of_replicas: 0)
         end
 
-        settings.merge!(options[:settings] || {})
+        settings.deep_merge!(options[:settings] || {})
 
         # synonyms
         synonyms = options[:synonyms] || []


### PR DESCRIPTION
Hi,  

I needed a way to change the autocomplete nGram without loosing all the analyzers.  
Maybe changing from `merge!` to `deep_merge!` would help somebody else who also wants to change only a portion of the settings ;-)

Now I can do something like this in my models: 

```
searchkick autocomplete: ['name', 'title'], settings: {
    analysis: {
        tokenizer: { 
            searchkick_autocomplete_ngram: { type: "nGram" }
        }
    }
}
```
