### PR TITLE
Allow nested any (or) filter execution

### DIFF
--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -248,6 +248,8 @@ module Searchkick
                     filters << {not: term_filters.call(field, op_value)}
                   when :all
                     filters << {terms: {field => op_value, execution: "and"}}
+                  when :any
+                    filters << {terms: {field => op_value, execution: "or"}}
                   else
                     range_query =
                       case op

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -40,7 +40,7 @@ class TestSql < Minitest::Unit::TestCase
     store [
       {name: "Product A", store_id: 1, in_stock: true, backordered: true, created_at: now, orders_count: 4, user_ids: [1, 2, 3]},
       {name: "Product B", store_id: 2, in_stock: true, backordered: false, created_at: now - 1, orders_count: 3, user_ids: [1]},
-      {name: "Product C", store_id: 3, in_stock: false, backordered: true, created_at: now - 2, orders_count: 2},
+      {name: "Product C", store_id: 3, in_stock: false, backordered: true, created_at: now - 2, orders_count: 2, user_ids: [1, 3]},
       {name: "Product D", store_id: 4, in_stock: false, backordered: false, created_at: now - 3, orders_count: 1},
     ]
     assert_search "product", ["Product A", "Product B"], where: {in_stock: true}
@@ -65,11 +65,13 @@ class TestSql < Minitest::Unit::TestCase
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{orders_count: [2, 4]}, {store_id: [1, 2]}]]}
     assert_search "product", ["Product A", "Product D"], where: {or: [[{orders_count: 1}, {created_at: {gte: now - 1}, backordered: true}]]}
     # all
-    assert_search "product", ["Product A"], where: {user_ids: {all: [1, 3]}}
+    assert_search "product", ["Product A", "Product C"], where: {user_ids: {all: [1, 3]}}
     assert_search "product", [], where: {user_ids: {all: [1, 2, 3, 4]}}
+    # any / nested terms
+    assert_search "product", ["Product B", "Product C"], where: {user_ids: {not: [2], any: [1,3]}}
     # not / exists
-    assert_search "product", ["Product C", "Product D"], where: {user_ids: nil}
-    assert_search "product", ["Product A", "Product B"], where: {user_ids: {not: nil}}
+    assert_search "product", ["Product D"], where: {user_ids: nil}
+    assert_search "product", ["Product A", "Product B", "Product C"], where: {user_ids: {not: nil}}
     assert_search "product", ["Product A", "Product C", "Product D"], where: {user_ids: [3, nil]}
     assert_search "product", ["Product B"], where: {user_ids: {not: [3, nil]}}
   end


### PR DESCRIPTION
Ran into an issue where we needed something like "any of these term values [1, 2, 3] but none of these [4, 5]" and couldn't figure out how to do it out of the box with searchkick. Added this :any (or) filter to accomplish this in a nested setting. Let me know if there's some better out-of-the-box way to do it. And thanks as always.
