### PR TITLE
Ensure that classes only get registered once

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -51,7 +51,8 @@ module Searchkick
     end
 
     def self.extended(klass)
-      (@descendents ||= []) << klass
+      @descendents ||= []
+      @descendents << klass unless @descendents.include?(klass)
     end
 
     private


### PR DESCRIPTION
I have an odd issue in my project where descendent classes are getting registered with searchkick more than once (even though models declarations are correct). This leads to rake searchkick:reindex:all executing each model reindex twice. I'm still working to track down where exactly this is happening in my code, but the extend callback here probably should refuse to re-register classes anyway, so thought I'd send this simple PR over.
