### PR TITLE
Add option to force search types

### DIFF
--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -350,7 +350,7 @@ module Searchkick
       payload[:fields] = [] if load
 
       tire_options = {load: load, payload: payload, size: per_page, from: offset}
-      tire_options[:type] = document_type if self != searchkick_klass
+      tire_options[:type] = handle_types(options[:types])
       search = Tire::Search::Search.new(index_name, tire_options)
       begin
         response = search.json
@@ -376,6 +376,12 @@ module Searchkick
 
       Searchkick::Results.new(response, search.options.merge(term: term))
     end
+
+    private
+      def handle_types(types)
+        return types.map(&:document_type) if types
+        document_type if self != searchkick_klass
+      end
 
   end
 end

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -25,6 +25,18 @@ class TestInheritance < Minitest::Unit::TestCase
     assert_equal 2, Animal.search("bear").size
   end
 
+  def test_force_one_type
+    store_names ["Green Bear"], Dog
+    store_names ["Blue Bear"], Cat
+    assert_equal ["Blue Bear"], Animal.search("bear", types: [Cat]).map(&:name)
+  end
+
+  def test_force_multiple_types
+    store_names ["Green Bear"], Dog
+    store_names ["Blue Bear"], Cat
+    assert_equal ["Green Bear", "Blue Bear"], Animal.search("bear", types: [Dog, Cat]).map(&:name)
+  end
+
   def test_child_autocomplete
     store_names ["Max"], Cat
     store_names ["Mark"], Dog


### PR DESCRIPTION
This is useful when your indice has different types of documents and you want ensure that just a certain type is returned.

Usage example:

``` ruby
Animal.search("bear", types: [Dog])
```
