### PR TITLE
Add support for has_child / has_parent filter

### DIFF
--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -267,6 +267,19 @@ module Searchkick
 
       # filters
       filters = where_filters.call(options[:where])
+
+      # has_child filter
+      if value = options[:has_child]
+        filters << {
+          has_child: {
+            type: value.delete(:type),
+            filter: {
+              and: where_filters.call(value[:where])
+            }
+          }
+        }
+      end
+
       if filters.any?
         payload[:filter] = {
           and: filters

--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -280,6 +280,18 @@ module Searchkick
         }
       end
 
+      # has_parent filter
+      if value = options[:has_parent]
+        filters << {
+          has_parent: {
+            type: value.delete(:type),
+            filter: {
+              and: where_filters.call(value[:where])
+            }
+          }
+        }
+      end
+
       if filters.any?
         payload[:filter] = {
           and: filters


### PR DESCRIPTION
I didn't find a pratice way to test this.
Maybe someone can help. :)

Example usage:
```ruby
Product.search('*', has_child: { type: <child document type>, where: <hash of where filters> }, has_parent: { type: <parent document type>, where: <hash of where filters> })
```