### PR TITLE
Search method naming conflict

### DIFF
--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -1,7 +1,7 @@
 module Searchkick
   module Search
 
-    def searchkick(term, options = {})
+    def search_kick(term, options = {})
       if term.is_a?(Hash)
         options = term
         term = nil


### PR DESCRIPTION
I'm having an issue with the `search` method conflicting with Mongoid's. Just a suggestion for a method name change.
