### PR TITLE
support range filter for array fields

### DIFF
--- a/lib/searchkick/search.rb
+++ b/lib/searchkick/search.rb
@@ -262,7 +262,11 @@ module Searchkick
                       else
                         raise "Unknown where operator"
                       end
-                    filters << {range: {field => range_query}}
+                    if existing = filters.find { |f| f[:range] && f[:range].keys.include?(field) }
+                      existing[:range][field].merge!(range_query)
+                    else
+                      filters << {range: {field => range_query}}
+                    end
                   end
                 end
               else

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -60,6 +60,7 @@ class TestSql < Minitest::Unit::TestCase
     assert_search "product", ["Product A", "Product B"], where: {store_id: [1, 2]}
     assert_search "product", ["Product B", "Product C", "Product D"], where: {store_id: {not: 1}}
     assert_search "product", ["Product C", "Product D"], where: {store_id: {not: [1, 2]}}
+    assert_search "product", ["Product A"], where: {user_ids: {lte: 2, gte: 2}}
     # or
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{in_stock: true}, {store_id: 3}]]}
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{orders_count: [2, 4]}, {store_id: [1, 2]}]]}


### PR DESCRIPTION
Consider a range query represented as a where clause in searchkick like this:

```
where: { user_ids: { gte: 5, lte: 10 }}
```

As of right now, this will generate _2_ separate filters, one for the gte and one for the lte. This is fine in most circumstances, but if you've got a field that is an array type, it presents some problems.

See http://elasticsearch-users.115913.n3.nabble.com/Numeric-range-quey-or-filter-in-an-array-field-possible-or-not-td4042967.html for an example use case. The example there is pretty illustrative. If you add two separate filters instead of one in that example, the results aren't what you'd expect.
