### PR TITLE
Accept options for search like `timeout`

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -281,6 +281,14 @@ module Searchkick
       # model and eagar loading
       load = options[:load].nil? ? true : options[:load]
 
+      # Other options
+      other_valid_options = %w[search_type routing scroll timeout]
+
+      other_valid_options.each do |option|
+        name = option.to_sym
+        payload[name] = options[name] if options[name]
+      end
+
       # An empty array will cause only the _id and _type for each hit to be returned
       # http://www.elasticsearch.org/guide/reference/api/search/fields/
       payload[:fields] = [] if load


### PR DESCRIPTION
`search_type`, `routing`, `scroll` and `timeout` are valid to be passed to tire (`Tire::Search::Search.new`) but they were ignored.
https://github.com/karmi/retire/blob/0512cc5e3528d9ab4c709f58a3ffb2e20c1f4196/lib/tire/dsl.rb#L25
