### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Plus:
 :tangerine: Battle-tested at [Instacart](https://www.instacart.com)
 
 [![Build Status](https://travis-ci.org/ankane/searchkick.png?branch=master)](https://travis-ci.org/ankane/searchkick)
+[![Inline docs](http://inch-pages.github.io/github/ankane/searchkick.png)](http://inch-pages.github.io/github/ankane/searchkick)
 
 We highly recommend tracking queries and conversions
 


### PR DESCRIPTION
Hi Andrew,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/ankane/searchkick.png)](http://inch-pages.github.io/github/ankane/searchkick)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/ankane/searchkick/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
