### PR TITLE
added the possibility to use a proc or lambda as index_name

### DIFF
--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -10,7 +10,7 @@ class TestInheritance < Minitest::Unit::TestCase
   end
 
   def test_child_index_name
-    assert_equal "animals_test", Dog.searchkick_index.name
+    assert_equal "animals-#{Date.today.year}", Dog.searchkick_index.name
   end
 
   def test_child_search

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,7 +143,7 @@ class Store
 end
 
 class Animal
-  searchkick autocomplete: [:name], suggest: [:name]
+  searchkick autocomplete: [:name], suggest: [:name], index_name: -> { "#{self.name.tableize}-#{Date.today.year}" }
 end
 
 Product.searchkick_index.delete if Product.searchkick_index.exists?


### PR DESCRIPTION
This was the only thing missing to make searchkick compatible with my multi-tenanted app.
Using [Apartment](https://github.com/influitive/apartment), I can just do this : 

``` ruby
searchkick index_name: -> { "#{self.name.tableize}-#{Apartment::Database.current_tenant}" }
```

...and voilà!
