### PR TITLE
similar: add per_page option

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Find similar items.
 
 ```ruby
 product = Product.first
-product.similar(fields: ["name"])
+product.similar(fields: ["name"], page: params[:page], per_page: 20)
 ```
 
 ### Geospatial Searches

--- a/lib/searchkick/similar.rb
+++ b/lib/searchkick/similar.rb
@@ -10,7 +10,7 @@ module Searchkick
       options[:where] ||= {}
       options[:where][:_id] ||= {}
       options[:where][:_id][:not] = id.to_s
-      options[:limit] ||= 10
+      options[:limit] ||= (options[:per_page] || 10)
       options[:similar] = true
       self.class.search(like_text, options)
     end

--- a/test/similar_test.rb
+++ b/test/similar_test.rb
@@ -17,4 +17,11 @@ class TestSimilar < Minitest::Unit::TestCase
     assert_order "Lucerne Fat Free Chocolate Milk", ["Lucerne Milk Chocolate Fat Free", "Clover Fat Free Milk"], similar: true
   end
 
+  def test_per_page_option
+    store_names ["Bag 1", "Bag 2", "Bag 3", "Bag 4", "Bag 5", "Bag 6", "Bag 7"]
+    bag_1 = Product.where(name: "Bag 1").first
+    assert_equal 6, bag_1.similar(fields: ["name"]).size
+    assert_equal 3, bag_1.similar(fields: ["name"], page: 1, per_page: 3).size
+    assert_equal 3, bag_1.similar(fields: ["name"], page: 2, per_page: 3).size
+  end
 end


### PR DESCRIPTION
Hi, the `similar` method doesn't support `per_page` option but `search` does. To make it consistent, I made the change.
