### PR TITLE
Add score for each hit in the returned set of results

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -284,11 +284,15 @@ module Searchkick
         @type = [options[:type] || klass].flatten.map{|v| searchkick_index.klass_document_type(v) }
       end
 
+      # Return score for each hit in the set of results.
+      score = options[:score].nil? ? false: options[:score]
+
       @body = payload
       @facet_limits = facet_limits
       @page = page
       @per_page = per_page
       @load = load
+      @score = score
     end
 
     def searchkick_index
@@ -339,7 +343,8 @@ module Searchkick
         page: @page,
         per_page: @per_page,
         load: @load,
-        includes: options[:include] || options[:includes]
+        includes: options[:include] || options[:includes],
+        score: @score
       }
       Searchkick::Results.new(searchkick_klass, response, opts)
     end

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -24,8 +24,10 @@ module Searchkick
           records = records.find(hit_ids)
           hit_ids = hit_ids.map(&:to_s)
           records.sort_by{|r| hit_ids.index(r.id.to_s)  }
+        elsif options[:score]
+          hits.map{ |hit| Hashie::Mash.new(hit["_source"]).merge(score: hit['_score']) }
         else
-          hits.map{|hit| Hashie::Mash.new(hit["_source"]) }
+          hits.map{ |hit| Hashie::Mash.new(hit["_source"]) }
         end
       end
     end


### PR DESCRIPTION
When handling search results it's usually quite handy to have the score for each hit in the data. Thus it's possible to, for example, sort on the results by "relevancy" on the client. This PR adds a score option and if set it will merge the score for object that is returned. I'm not sure it's the best name for the option though?
