### PR TITLE
Improved kaminari support

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -90,6 +90,16 @@ module Searchkick
       current_page < total_pages ? (current_page + 1) : nil
     end
 
+    # First page of the collection ?
+    def first_page?
+      current_page == 1
+    end
+
+    # Last page of the collection?
+    def last_page?
+      current_page >= total_pages
+    end
+
     protected
 
     def hits


### PR DESCRIPTION
Problem: searchkick does not play nice together with kaminari.

Details: kaminari has `link_to_previous_page` and `link_to_next_page` helpers which depend on `first_page?` and `last_page?` methods (https://github.com/amatsuda/kaminari/blob/master/lib/kaminari/helpers/action_view_extension.rb#L42).

I added those methods to improve kaminari support.
