### PR TITLE
Add pagination `padding` option to #search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Plays nicely with kaminari and will_paginate.
 
 ```ruby
 # controller
-@products = Product.search "milk", page: params[:page], per_page: 20
+@products = Product.search "milk", page: params[:page], per_page: 20, padding: 5
 
 # view
 <%= paginate @products %>

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -36,9 +36,10 @@ module Searchkick
       operator = options[:operator] || (options[:partial] ? "or" : "and")
 
       # pagination
+      padding = [options[:padding].to_i, 0].max
       page = [options[:page].to_i, 1].max
       per_page = (options[:limit] || options[:per_page] || 100000).to_i
-      offset = options[:offset] || (page - 1) * per_page
+      offset = options[:offset] || padding + (page - 1) * per_page
 
       conversions_field = searchkick_options[:conversions]
       personalize_field = searchkick_options[:personalize]
@@ -296,6 +297,7 @@ module Searchkick
 
       @body = payload
       @facet_limits = facet_limits
+      @padding = padding
       @page = page
       @per_page = per_page
       @load = load
@@ -352,6 +354,7 @@ module Searchkick
       end
 
       opts = {
+        padding: @padding,
         page: @page,
         per_page: @per_page,
         load: @load,

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -80,6 +80,10 @@ module Searchkick
       options[:page]
     end
 
+    def padding
+      options[:padding]
+    end
+
     def per_page
       options[:per_page]
     end
@@ -90,7 +94,7 @@ module Searchkick
     end
 
     def offset_value
-      current_page * per_page
+      padding + current_page * per_page
     end
     alias_method :offset, :offset_value
 

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -20,9 +20,10 @@ class TestSql < Minitest::Unit::TestCase
 
   def test_pagination
     store_names ["Product A", "Product B", "Product C", "Product D", "Product E"]
-    products = Product.search("product", order: {name: :asc}, page: 2, per_page: 2)
-    assert_equal ["Product C", "Product D"], products.map(&:name)
+    products = Product.search("product", order: {name: :asc}, page: 2, per_page: 2, padding: 1)
+    assert_equal ["Product D", "Product E"], products.map(&:name)
     assert_equal 2, products.current_page
+    assert_equal 1, products.padding
     assert_equal 2, products.per_page
     assert_equal 2, products.size
     assert_equal 2, products.length
@@ -30,8 +31,8 @@ class TestSql < Minitest::Unit::TestCase
     assert_equal 5, products.total_count
     assert_equal 5, products.total_entries
     assert_equal 2, products.limit_value
-    assert_equal 4, products.offset_value
-    assert_equal 4, products.offset
+    assert_equal 5, products.offset_value
+    assert_equal 5, products.offset
     assert !products.first_page?
     assert !products.last_page?
     assert !products.empty?


### PR DESCRIPTION
This allows you to pad a number of records that is not a multiple of the page size.

See [kaminari gem](https://github.com/amatsuda/kaminari) for usage example.
