### PR TITLE
Fixing issue with STI and bulk import

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -40,6 +40,16 @@ module Searchkick
     end
 
     def import(records)
+      if records.first.respond_to?(:type)
+        records.group_by { |item| item.type }.each_pair do |type, items|
+          client_import items.select { |item| item.should_index? }
+        end
+      else
+        client_import records
+      end
+    end
+
+    def client_import(records)
       if records.any?
         client.bulk(
           index: name,

--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -57,7 +57,7 @@ module Searchkick
       scope = scope.search_import if scope.respond_to?(:search_import)
       if scope.respond_to?(:find_in_batches)
         scope.find_in_batches batch_size: batch_size do |batch|
-          index.import batch.select{|item| item.should_index? }
+          index.import batch.select{|item| item.should_index?}
         end
       else
         # https://github.com/karmi/tire/blob/master/lib/tire/model/import.rb


### PR DESCRIPTION
- When reindexing, the Index.import method checks the type of the
  first record and uses that for all records indexed.
- Send records through a group_by filter first and then index them in
  groups by type
