### PR TITLE
Allow classes to set document_type.

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -71,6 +71,16 @@ module Searchkick
       klass_document_type(record.class)
     end
 
+    def document_type(record)
+      klass = record.class
+
+      if klass.respond_to?(:document_type) && klass.document_type
+        klass = klass.document_type
+      end
+
+      klass_document_type(klass)
+    end
+
     def search_id(record)
       record.id.is_a?(Numeric) ? record.id : record.id.to_s
     end


### PR DESCRIPTION
This functionality used to exist in SearchKick but no longer does.
In some cases of STI it may be desireable to have child classes use
the same mapping set as the parent class, rather then setting new
mappings for each subclass.  This allows you to easily set the
document_type method on a class in order to allow all STI tables
to use the same mappings.
