### PR TITLE
Add prev_page method to results

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -112,6 +112,7 @@ module Searchkick
     def previous_page
       current_page > 1 ? (current_page - 1) : nil
     end
+    alias_method :prev_page, :previous_page
 
     def next_page
       current_page < total_pages ? (current_page + 1) : nil

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -33,6 +33,9 @@ class TestSql < Minitest::Unit::TestCase
     assert_equal 2, products.limit_value
     assert_equal 3, products.offset_value
     assert_equal 3, products.offset
+    assert_equal 3, products.next_page
+    assert_equal 1, products.previous_page
+    assert_equal 1, products.prev_page
     assert !products.first_page?
     assert !products.last_page?
     assert !products.empty?


### PR DESCRIPTION
Needed for compatibility with kaminari pagination. Addresses ankane/searchkick#228.

Kaminari pagination api implements a `prev_page` method. This branch aliases `prev_method` to `previous_method`.
