### PR TITLE
Add option to skip importing records when reindexing

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -3,7 +3,9 @@ module Searchkick
 
     # https://gist.github.com/jarosan/3124884
     # http://www.elasticsearch.org/blog/changing-mapping-with-zero-downtime/
-    def reindex(skip_import = false)
+    def reindex(options = { import: true })
+      skip_import = options.key?(:import) && !options[:import]
+
       alias_name = searchkick_index.name
       new_name = alias_name + "_" + Time.now.strftime("%Y%m%d%H%M%S%L")
       index = Searchkick::Index.new(new_name)


### PR DESCRIPTION
I think we need options to skip importing records when reindexing a model e.g `Product.reindex`

This could be useful on development with lot records (hundreds of thousand or millions records).
Let say I have defined/modified some mapping and settings at `Product`. I have to wait all records being imported so that new mapping, settings, analyzer to take effect.

I know this is very specific use case but would be nice if we have this feature.
