### PR TITLE
Add Searchkick::Results#entry_name method for kaminari compatibility

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -88,6 +88,10 @@ module Searchkick
       klass.model_name
     end
 
+    def entry_name
+      model_name.human.downcase
+    end
+
     def total_count
       response["hits"]["total"]
     end

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -22,6 +22,7 @@ class TestSql < Minitest::Test
     store_names ["Product A", "Product B", "Product C", "Product D", "Product E", "Product F"]
     products = Product.search("product", order: {name: :asc}, page: 2, per_page: 2, padding: 1)
     assert_equal ["Product D", "Product E"], products.map(&:name)
+    assert_equal "product", products.entry_name
     assert_equal 2, products.current_page
     assert_equal 1, products.padding
     assert_equal 2, products.per_page

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ Minitest::Test = Minitest::Unit::TestCase unless defined?(Minitest::Test)
 File.delete("elasticsearch.log") if File.exists?("elasticsearch.log")
 Searchkick.client.transport.logger = Logger.new("elasticsearch.log")
 
+I18n.config.enforce_available_locales = true
+
 if defined?(Mongoid)
 
   def mongoid2?


### PR DESCRIPTION
From [kaminari 0.16.0](https://github.com/amatsuda/kaminari/releases/tag/v0.16.0) (more specifically from this commit: https://github.com/amatsuda/kaminari/commit/507fb73b09475a0efbd99d0398bf4a3c9632ca18), `#page_entries_info` requires paginatable objects to have `#entry_name` method. `SearchKick::Results` should also have it so it'll play nice together with kaminari.
