### PR TITLE
Fix import logging exception in case of empty records array

### DIFF
--- a/lib/searchkick/logging.rb
+++ b/lib/searchkick/logging.rb
@@ -38,6 +38,7 @@ module Searchkick
     alias_method_chain :remove, :instrumentation
 
     def import_with_instrumentation(records)
+      return unless records.any?
       event = {
         name: "#{records.first.searchkick_klass.name} Import",
         count: records.size


### PR DESCRIPTION
Fix for NoMethodError in logging empty records array import.

Currently you can get exception if `Model#should_index?` returns _false_ for all batch during indexing(`Model.reindex`). You can simulate this with setting `def should_index?; false; end`
