### PR TITLE
add indices_boost option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ boost_where: {user_id: {value: 1, factor: 100}} # default factor is 1000
 boost_where: {user_id: [{value: 1, factor: 100}, {value: 2, factor: 200}]}
 ```
 
+Boost indices when searching across more than one index
+
+```ruby
+indices_boost: { Animal => 1, Product => 200 }
+```
+
 [Conversions](#keep-getting-better) are also a great way to boost.
 
 ### Get Everything

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -141,4 +141,11 @@ class BoostTest < Minitest::Test
     ]
     assert_order "san", ["San Francisco", "San Antonio", "San Marino"], boost_by_distance: {field: :location, origin: {lat: 37, lon: -122}, scale: "1000mi"}
   end
+
+  def test_boost_by_indices
+    store_names ["Rex"], Animal
+    store_names ["Rexx"], Product
+
+    assert_order "Rex", ["Rexx", "Rex"], {index_name: [Animal, Product], indices_boost: {Animal => 1, Product => 200}}, Store
+  end
 end


### PR DESCRIPTION
Hi, I'd like to add [indices_boost](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-index-boost.html) support. For example:

```ruby
User.search("*", index_name: ["foo", "bar"], indices_boost: { foo: 1, bar: 2 })
```