### PR TITLE
Allow for primary_key to be passed as an option

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -410,6 +410,7 @@ module Searchkick
         includes: options[:include] || options[:includes],
         json: !options[:json].nil?
       }
+      opts.merge!({primary_key: searchkick_options[:primary_key]}) if searchkick_options.has_key?(:primary_key)
       Searchkick::Results.new(searchkick_klass, response, opts)
     end
 

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -27,7 +27,9 @@ module Searchkick
               records = records.includes(options[:includes])
             end
             results[type] =
-              if records.respond_to?(:primary_key)
+              if options.has_key?(:primary_key)
+                records.where(options[:primary_key] => grouped_hits.map{|hit| hit["_id"] }).to_a
+              elsif records.respond_to?(:primary_key)
                 records.where(records.primary_key => grouped_hits.map{|hit| hit["_id"] }).to_a
               else
                 records.queryable.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
@@ -36,7 +38,11 @@ module Searchkick
 
           # sort
           hits.map do |hit|
-            results[hit["_type"]].find{|r| r.id.to_s == hit["_id"].to_s }
+            if options.has_key?(:primary_key)
+              results[hit["_type"]].find{|r| r.send(options[:primary_key]).to_s == hit["_id"].to_s }
+            else
+              results[hit["_type"]].find{|r| r.id.to_s == hit["_id"].to_s }
+            end
           end.compact
         else
           hits.map do |hit|


### PR DESCRIPTION
We had a need to use an alternate key for lookups so we add an option that allows you to specify primary_key for database lookups.
