### PR TITLE
Add options for query : min_score, facets/all_terms, facets/field

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -47,6 +47,8 @@ module Searchkick
       padding = [options[:padding].to_i, 0].max
       offset = options[:offset] || (page - 1) * per_page + padding
 
+      min_score = options[:min_score] || 0
+
       # model and eagar loading
       load = options[:load].nil? ? true : options[:load]
 
@@ -222,7 +224,8 @@ module Searchkick
         payload = {
           query: payload,
           size: per_page,
-          from: offset
+          from: offset,
+          min_score: min_score
         }
         payload[:explain] = options[:explain] if options[:explain]
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -268,7 +268,8 @@ module Searchkick
                 terms_stats: {
                   key_field: field,
                   value_script: "doc.score",
-                  size: size
+                  size: size,
+                  all_terms: facet_options[:all_terms] || false
                 }
               }
             else
@@ -276,6 +277,8 @@ module Searchkick
                 terms: {
                   field: field,
                   size: size
+                  size: size,
+                  all_terms: facet_options[:all_terms] || false
                 }
               }
             end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -266,7 +266,7 @@ module Searchkick
             elsif facet_options[:stats]
               payload[:facets][field] = {
                 terms_stats: {
-                  key_field: field,
+                  key_field: facet_options[:field] || field,
                   value_script: "doc.score",
                   size: size,
                   all_terms: facet_options[:all_terms] || false
@@ -275,8 +275,7 @@ module Searchkick
             else
               payload[:facets][field] = {
                 terms: {
-                  field: field,
-                  size: size
+                  field: facet_options[:field] || field,
                   size: size,
                   all_terms: facet_options[:all_terms] || false
                 }

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -86,6 +86,12 @@ class TestFacets < Minitest::Test
     assert_equal true, query.body[:facets][:name][:terms][:all_terms]
   end
 
+  # field
+   def test_can_specify_field_for_facet
+    query = Product.search({ query: { name: "milk"}, facets: {name: { field: "name.id"}} }, execute: false)
+    assert_equal "name.id", query.body[:facets][:name][:terms][:field]
+  end
+
   protected
 
   def store_facet(options)

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -75,6 +75,17 @@ class TestFacets < Minitest::Test
     assert_equal expected_facets_keys, facets.first.keys
   end
 
+  # all_terms
+   def test_all_term_default_to_false
+    query = Product.search({ query: { name: "milk"}, facets: {name: {}} }, execute: false)
+    assert_equal false, query.body[:facets][:name][:terms][:all_terms]
+  end
+
+  def test_use_all_terms_option
+    query = Product.search({ query: { name: "milk"}, facets: {name: {all_terms: true}} }, execute: false)
+    assert_equal true, query.body[:facets][:name][:terms][:all_terms]
+  end
+
   protected
 
   def store_facet(options)

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -283,6 +283,18 @@ class TestSql < Minitest::Test
     assert_kind_of Hash, Product.search("product", load: false, include: [:store]).first
   end
 
+  # min_score
+
+   def test_min_score_default_to_zero
+    query = Product.search("milk", execute: false)
+    assert_equal 0, query.body[:min_score]
+  end
+
+  def test_should_use_min_score_param
+    query = Product.search({ query: { name: "milk"}, min_score: 1 }, execute: false)
+    assert_equal 1, query.body[:min_score]
+  end
+
   # select
 
   def test_select


### PR DESCRIPTION
Hello,

I added options to query : 
- min_score => Required when we want to filter pertinence results 
- facets/all_terms => Allow you to pass the all_terms (bool) param for facets
- facets/field => You can now specify the field for facet. 

I did this fix because I migrated my project to searchkick and needed this options. I am not an expert of ES, so, be critical, I maybe made huge mistakes !
