### PR TITLE
Adds query function parameter to boost_where

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -196,14 +196,16 @@ module Searchkick
           boost_where.merge!(options[:personalize])
         end
         boost_where.each do |field, value|
+          factor = 1000
+          score_query = :term
           if value.is_a?(Hash)
-            value, factor = value[:value], value[:factor]
-          else
-            factor = 1000
+            factor = value[:factor].to_f if value[:factor]
+            score_query = value[:query] if value[:query]
+            value = value[:value]
           end
           custom_filters << {
             filter: {
-              term: {field => value}
+              score_query => {field => value}
             },
             boost_factor: factor
           }

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -102,6 +102,7 @@ class TestBoost < Minitest::Test
     ]
     assert_first "tomato", "Tomato B", boost_where: {user_ids: 2}
     assert_first "tomato", "Tomato B", boost_where: {user_ids: {value: 2, factor: 10}}
+    assert_first "tomato", "Tomato B", boost_where: {user_ids: {value: [3, 4, 5], factor: 10, query: :terms}}
   end
 
 end


### PR DESCRIPTION
In some cases it is actual to have other function_score query than the `term` query. The pull requests add such ability.