### PR TITLE
Modify the query scoring with custom functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,17 @@ Bounded by a box
 City.search "san", where: {location: {top_left: [38, -123], bottom_right: [37, -122]}}
 ```
 
+Modify search score by proximity to a point:
+
+```ruby
+City.search "san", proximity_factor: { field: :location, origin: [37, -122] } # field and origin mandatory
+City.search "san", proximity_factor: { field: :location, origin: [37, -122], function: :linear, scale: "30mi", decay: 0.5 } # at 30mi, decrease score by 50%
+```
+
+The difference between where with a geo_point and proximity_factor is that the former is a hard cutoff that simply includes or excludes results but has no impact on the order of results, whereas the latter smoothly modifies the search score so that the results with the best match for the query text and the distance are returned.
+
+See [more details on modifying the score by proximity](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_decay_functions).
+
 ## Inheritance
 
 Searchkick supports single table inheritance.

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -261,6 +261,15 @@ class TestSql < Minitest::Test
     assert_search "product", ["Product"], where: {latitude: {gt: 99}}
   end
 
+  def test_proximity
+    store [
+      {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
+      {name: "San Antonio", latitude: 29.4167, longitude: -98.5000},
+      {name: "San Marino", latitude: 43.9333, longitude: 12.4667}
+    ]
+    assert_order "san", ["San Francisco", "San Antonio", "San Marino"], proximity_factor: {field: :location, origin: [37, -122]}
+  end
+
   # load
 
   def test_load_default


### PR DESCRIPTION
First of all, thanks Andrew for the cool gem!

I wanted to customize the score by factoring in the distance from a point. The best way to do this seems to be with [function_score](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html).

There currently isn't a way to pass in a custom function_score argument. Other users apparently want to do this too as in #241.

This PR adds a :function_score option to the search method. function_score should be a hash that contains an array of functions and an optional score_mode (defaults to multiply).

I use it like this:

``` ruby
Model.search query_text, :function_score =>
    {
      :functions => [
        {
          :gauss => {
            # The location field is a geo_point in Model
            :location =>  {
              # Longitude, Latitude to conform to GeoJSON
              :origin => [location[:longitude], location[:latitude]],
              :scale => "50mi",
              :decay => 0.9
            }
          }
        }
      ]
    }
```
