### PR TITLE
Use string interpolation to get index name

### DIFF
--- a/lib/searchkick/reindex.rb
+++ b/lib/searchkick/reindex.rb
@@ -7,7 +7,7 @@ module Searchkick
       skip_import = options[:import] == false
 
       alias_name = searchkick_index.name
-      new_name = alias_name + "_" + Time.now.strftime("%Y%m%d%H%M%S%L")
+      new_name = "#{alias_name}_#{Time.now.strftime('%Y%m%d%H%M%S%L')}"
       index = Searchkick::Index.new(new_name)
 
       clean_indices


### PR DESCRIPTION
- String interpolation works faster
- Now you are able to pass even symbol in the option for custom index name
- The code is clearer
