### PR TITLE
Include indexed search_data on demand

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -355,10 +355,10 @@ module Searchkick
 
         # An empty array will cause only the _id and _type for each hit to be returned
         # http://www.elasticsearch.org/guide/reference/api/search/fields/
-        if load
+        if options[:select]
+          payload[:fields] = options[:select] unless options[:select].respond_to?(:to_sym) and options[:select].to_sym == :all
+        elsif load
           payload[:fields] = []
-        elsif options[:select]
-          payload[:fields] = options[:select]
         end
 
         if options[:type] or klass != searchkick_klass

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -298,6 +298,13 @@ class TestSql < Minitest::Test
     assert_equal [1, 2], result.user_ids
   end
 
+  def test_select_all
+    store [{name: "Product A", user_ids: [1, 2]}]
+    hit = Product.search("product", select: :all).__send__(:hits).first
+    assert_equal hit["_source"]["name"], "Product A"
+    assert_equal hit["_source"]["user_ids"], [1, 2]
+  end
+
   def test_nested_object
     aisle = {"id" => 1, "name" => "Frozen"}
     store [{name: "Product A", aisle: aisle}]


### PR DESCRIPTION
Now we can access indexed model data with load: true option on.
Example: `MyModel.search("awesome", limit: 1, include_search_data: true).results.first.response_search_data`
