### PR TITLE
move results db queries into a dedicated method

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -26,17 +26,7 @@ module Searchkick
             if options[:includes]
               records = records.includes(options[:includes])
             end
-            results[type] =
-              if records.respond_to?(:primary_key) and records.primary_key
-                # ActiveRecord
-                records.where(records.primary_key => grouped_hits.map{|hit| hit["_id"] }).to_a
-              elsif records.respond_to?(:all) and records.all.respond_to?(:for_ids)
-                # Mongoid 2
-                records.all.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
-              else
-                # Mongoid 3+
-                records.queryable.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
-              end
+            results[type] = results_query(records, grouped_hits)
           end
 
           # sort
@@ -143,5 +133,19 @@ module Searchkick
       @response["hits"]["hits"]
     end
 
+    private
+
+    def results_query(records, grouped_hits)
+      if records.respond_to?(:primary_key) and records.primary_key
+        # ActiveRecord
+        records.where(records.primary_key => grouped_hits.map{|hit| hit["_id"] }).to_a
+      elsif records.respond_to?(:all) and records.all.respond_to?(:for_ids)
+        # Mongoid 2
+        records.all.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
+      else
+        # Mongoid 3+
+        records.queryable.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
+      end
+    end
   end
 end


### PR DESCRIPTION
Pretty easy one here. This makes it easier to adapt Searchkick to other database drivers. If someone has a database with unique query syntax but don't think it warrants a PR to add it to the gem, they shouldn't have to override the entire `results` method.
