### PR TITLE
Separate DB query logic, make it easy to add custom behavior

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -142,16 +142,10 @@ module Searchkick
       elsif records.respond_to?(:all) and records.all.respond_to?(:for_ids)
         # Mongoid 2
         records.all.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
-      elsif records.respond_to?(:queryable)
+      else
         # Mongoid 3+
         records.queryable.for_ids(grouped_hits.map{|hit| hit["_id"] }).to_a
-      else
-        custom_query(records, grouped_hits)
       end
-    end
-
-    def custom_query(records, grouped_hits)
-      raise 'Query method for records is unknown'
     end
   end
 end


### PR DESCRIPTION
Let's try this again! :-)

If someone wants to add a custom DB query, they shouldn't have to override the entire `results` method. This separates out all of the database logic into its own method, it makes it a bit easier to work with if they do need to override one of the default cases. It also adds a `custom_query` method as the `else` case instead of the Mongoid 3+ query. 

If someone is not already overriding the behavior and they're not using a DB compatible with the existing query logic, they'll get a more descriptive error than `undefined method queryable`. If they do have a custom need, they can write their own `custom_query` like this:

``` ruby
module Searchkick
  class Results  
    def custom_query(records, grouped_hits)
      records.array_load(grouped_hits.map { |hit| hit['_id'].to_i })
    end
  end
end
```
