### PR TITLE
Rescue from division by zero error

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -101,7 +101,7 @@ module Searchkick
     end
 
     def total_pages
-      (total_count / per_page.to_f).ceil
+      (total_count / per_page.to_f).ceil rescue 0
     end
     alias_method :num_pages, :total_pages
 


### PR DESCRIPTION
`per_page` can be 0