### PR TITLE
Allow '_all' to be used as a search field

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -25,11 +25,15 @@ module Searchkick
             options[:fields].map{|f| "#{f}.autocomplete" }
           else
             options[:fields].map do |value|
-              k, v = value.is_a?(Hash) ? value.to_a.first : [value, :word]
-              k2, boost = k.to_s.split("^", 2)
-              field = "#{k2}.#{v == :word ? "analyzed" : v}"
-              boost_fields[field] = boost.to_i if boost
-              field
+              if value == '_all'
+                value
+              else
+                k, v = value.is_a?(Hash) ? value.to_a.first : [value, :word]
+                k2, boost = k.to_s.split("^", 2)
+                field = "#{k2}.#{v == :word ? "analyzed" : v}"
+                boost_fields[field] = boost.to_i if boost
+                field
+              end
             end
           end
         else


### PR DESCRIPTION
This lets you set index type (e.g. `word_middle`) for some fields but still search every field in the index.