### PR TITLE
Add ability to reverse where using not filter

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -455,6 +455,8 @@ module Searchkick
           value.each do |or_clause|
             filters << {or: or_clause.map{|or_statement| {and: where_filters(or_statement)} }}
           end
+        elsif field == :not
+          filters << {not: {and: where_filters(value)}}
         else
           # expand ranges
           if value.is_a?(Range)

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -65,6 +65,7 @@ class TestSql < Minitest::Test
     assert_search "product", ["Product A", "Product B"], where: {created_at: {gte: now - 1}}
     assert_search "product", ["Product D"], where: {created_at: {lt: now - 2}}
     assert_search "product", ["Product C", "Product D"], where: {created_at: {lte: now - 2}}
+    assert_search "product", ["Product C", "Product D"], where: {not: {created_at: {gte: now - 1}}}
     # integer
     assert_search "product", ["Product A"], where: {store_id: {lt: 2}}
     assert_search "product", ["Product A", "Product B"], where: {store_id: {lte: 2}}
@@ -76,6 +77,7 @@ class TestSql < Minitest::Test
     assert_search "product", ["Product A", "Product B"], where: {store_id: [1, 2]}
     assert_search "product", ["Product B", "Product C", "Product D"], where: {store_id: {not: 1}}
     assert_search "product", ["Product C", "Product D"], where: {store_id: {not: [1, 2]}}
+    assert_search "product", ["Product C", "Product D"], where: {not: {store_id: [1, 2]}}
     assert_search "product", ["Product A"], where: {user_ids: {lte: 2, gte: 2}}
     # or
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{in_stock: true}, {store_id: 3}]]}
@@ -91,6 +93,7 @@ class TestSql < Minitest::Test
     assert_search "product", ["Product A", "Product B", "Product C"], where: {user_ids: {not: nil}}
     assert_search "product", ["Product A", "Product C", "Product D"], where: {user_ids: [3, nil]}
     assert_search "product", ["Product B"], where: {user_ids: {not: [3, nil]}}
+    assert_search "product", ["Product B", "Product D"], where: {not: {user_ids: 3}}
   end
 
   def test_where_string


### PR DESCRIPTION
Adds ability to create negative filters: for example `{not: {location: {geo_distance:....` , `{not: {user_id: {in: [1,2]}}}`

It is very useful to reverse where queries.
