### PR TITLE
Add option for retaining indexes to Model#reindex

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -47,8 +47,8 @@ module Searchkick
             searchkick_index.reindex_scope(searchkick_klass, options)
           end
 
-          def clean_indices
-            searchkick_index.clean_indices
+          def clean_indices(retain = false)
+            searchkick_index.clean_indices(retain)
           end
 
           def searchkick_import(options = {})

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -20,6 +20,28 @@ class TestIndex < Minitest::Test
     assert !old_index.exists?
   end
 
+  def test_clean_indicies_retain_previous
+    oldest_index = Searchkick::Index.new("products_test_20130801000000000")
+    middle_index = Searchkick::Index.new("products_test_20130801000000001")
+    newest_index = Searchkick::Index.new("products_test_20130801000000002")
+
+    oldest_index.delete if oldest_index.exists?
+    middle_index.delete if middle_index.exists?
+    newest_index.delete if newest_index.exists?
+
+    # create indexes
+    oldest_index.create
+    middle_index.create
+    newest_index.create
+
+    Product.clean_indices(:previous)
+
+    assert Product.searchkick_index.exists?
+    assert newest.exists?
+    assert !middle.exists?
+    assert !oldest.exists?
+  end
+
   def test_clean_indices_old_format
     old_index = Searchkick::Index.new("products_test_20130801000000")
     old_index.create


### PR DESCRIPTION
I want to resolve issue #356 regarding adding an option to retain indexes to Model#reindex.  In it's current form this PR is not complete as it does not feature tests, nor the ability to utilize this feature in searchkick index tasks.  I just wanted to get feedback on the strategy.

@ankane reindex_scope seemed overly complicated and I simplified it a little bit.. I may have missed something but this seems to work as expected.. wondering if I can get your thoughts.
