### PR TITLE
Add an option to enable transpositions in fuzzy search

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -107,9 +107,10 @@ module Searchkick
                 misspellings = options.key?(:misspellings) ? options[:misspellings] : options[:mispellings] # why not?
                 if misspellings != false
                   edit_distance = (misspellings.is_a?(Hash) && (misspellings[:edit_distance] || misspellings[:distance])) || 1
+                  transpositions = (misspellings.is_a?(Hash) && (misspellings[:fuzzy_transpositions] || misspellings[:transpositions])) || false
                   qs.concat [
-                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search"),
-                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search2")
+                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search", fuzzy_transpositions: transpositions),
+                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search2", fuzzy_transpositions: transpositions)
                   ]
                 end
               elsif field.end_with?(".exact")

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -91,6 +91,12 @@ class TestMatch < Minitest::Test
     assert_search "ringo", ["Bingo"]
   end
 
+  def test_edit_distance_one_transposition
+    store_names ["Bingo"]
+    assert_search "binog", [], { misspellings: { transpositions: false } }
+    assert_search "binog", ["Bingo"], { misspellings: { transpositions: true } }
+  end
+
   def test_edit_distance_long_word
     store_names ["thisisareallylongword"]
     assert_search "thisisareallylongwor", ["thisisareallylongword"] # missing letter


### PR DESCRIPTION
This change allows transpositions (switching two characters) to be counted as a single operation when calculating the edit distance. For example:

User.search(''Jonh", { misspellings: { edit_distance: 1, transpositions: true } })

would return "John" as a match.