### PR TITLE
Add range option to boost filters.

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -547,6 +547,8 @@ module Searchkick
         else
           {in: {field => value}}
         end
+      elsif value.is_a?(Range)
+        {range: { field => { gte: value.min, lte: value.max } }}
       elsif value.nil?
         {missing: {"field" => field, existence: true, null_value: true}}
       elsif value.is_a?(Regexp)

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -112,6 +112,7 @@ class TestBoost < Minitest::Test
     assert_first "tomato", "Tomato B", boost_where: {user_ids: {value: 2, factor: 10}}
     assert_first "tomato", "Tomato B", boost_where: {user_ids: {value: [1, 4], factor: 10}}
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_where: {user_ids: [{value: 1, factor: 10}, {value: 3, factor: 20}]}
+    assert_first "tomato", "Tomato B", boost_where: { user_ids: 2..9 }
   end
 
   def test_boost_by_distance


### PR DESCRIPTION
    I've trying to boost results beetween two values without
    success, so I added two simple lines to allow that feature.
    Now, you could boost results beetween two values sending
    a Range object as parameter.