### PR TITLE
[Facets] Support overriding field in facet search

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -301,7 +301,7 @@ module Searchkick
             else
               payload[:facets][field] = {
                 terms: {
-                  field: field,
+                  field: facet_options[:field] || field,
                   size: size
                 }
               }

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -21,6 +21,12 @@ class TestFacets < Minitest::Test
     assert_equal ({1 => 1}), store_facet(facets: {store_id: {where: {in_stock: true}}})
   end
 
+  def test_field
+    assert_equal ({1 => 1, 2 => 2}), store_facet(facets: {store_id: {}})
+    assert_equal ({1 => 1, 2 => 2}), store_facet(facets: {store_id: {field: "store_id"}})
+    assert_equal ({1 => 1, 2 => 2}), store_facet({facets: {store_id_new: {field: "store_id"}}}, "store_id_new")
+  end
+
   def test_limit
     facet = Product.search("Product", facets: {store_id: {limit: 1}}).facets["store_id"]
     assert_equal 1, facet["terms"].size
@@ -78,8 +84,8 @@ class TestFacets < Minitest::Test
 
   protected
 
-  def store_facet(options)
-    Hash[Product.search("Product", options).facets["store_id"]["terms"].map { |v| [v["term"], v["count"]] }]
+  def store_facet(options, facet_key="store_id")
+    Hash[Product.search("Product", options).facets[facet_key]["terms"].map { |v| [v["term"], v["count"]] }]
   end
 
 end


### PR DESCRIPTION
Currently Searchkick defaults to the facet hash key to determine the field it should aggregate on. This commit allows someone using facets search to specify the exact elastic field they want the facet to aggregate on. This is useful if the name of the facet key doesn't match the field they want to search on.

It also benefits people that want two separate aggregations (i.e. with different where clauses) on the same field. Currently this is not possible since the hash keys would have to be the same, therefore causing one to override the other. With this commit, the 2nd hash key can be something different but the field aggregated is still the same.