### PR TITLE
Aggregations support

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -376,23 +376,24 @@ module Searchkick
           end
 
           payload[:aggregations] = {}
-          aggregations.each do |field, aggregation_options|
-            aggregation_name = aggregation_options[:name] || field.to_sym
+          aggregations.each do |key, aggregation_options|
+            field = aggregation_options[:field] || key
 
             if aggregation_options[:ranges]
-              payload[:aggregations][aggregation_name] = {
+              payload[:aggregations][key] = {
                 range: {
-                  field => aggregation_options[:ranges]
+                  field: field,
+                  ranges: aggregation_options[:ranges]
                 }
               }
             elsif aggregation_options[:stats]
-              payload[:aggregations][aggregation_name] = {
+              payload[:aggregations][key] = {
                 stats: {
                   field: field
                 }
               }
             else
-              payload[:aggregations][aggregation_name] = {
+              payload[:aggregations][key] = {
                 terms: {
                   field: field
                 }

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -401,11 +401,11 @@ module Searchkick
             end
           end
 
-          if options[:smart_aggregations] && !filters.empty?
+          if options[:unfiltered_aggregations]
             aggregations = payload[:aggregations]
             payload[:aggregations] = {
-              searchkick_filtered_aggregation: {
-                filter: payload[:query][:filtered][:filter],
+              searchkick_unfiltered_aggregation: {
+                global: {},
                 aggregations: aggregations
               }
             }

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -79,10 +79,6 @@ module Searchkick
     end
 
     def aggregations
-      if response["aggregations"]
-        filtered_aggregation = response["aggregations"]["searchkick_unfiltered_aggregation"]
-        return filtered_aggregation if filtered_aggregation
-      end
       response["aggregations"]
     end
 

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -78,6 +78,14 @@ module Searchkick
       response["facets"]
     end
 
+    def aggregations
+      if response["aggregations"]
+        filtered_aggregation = response["aggregations"]["searchkick_filtered_aggregation"]
+        return filtered_aggregation if filtered_aggregation
+      end
+      response["aggregations"]
+    end
+
     def model_name
       klass.model_name
     end

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -80,7 +80,7 @@ module Searchkick
 
     def aggregations
       if response["aggregations"]
-        filtered_aggregation = response["aggregations"]["searchkick_filtered_aggregation"]
+        filtered_aggregation = response["aggregations"]["searchkick_unfiltered_aggregation"]
         return filtered_aggregation if filtered_aggregation
       end
       response["aggregations"]

--- a/test/aggregations_test.rb
+++ b/test/aggregations_test.rb
@@ -41,9 +41,9 @@ class TestAggregations < Minitest::Test
     assert_equal expected_aggregations_keys, aggregations.keys
   end
 
-  def test_smart_aggregations
-    options = {where: {store_id: 2}, aggregations: [:store_id], smart_aggregations: true}
-    assert_equal ({2 => 2}), store_bucket_aggregation(options)
+  def test_unfiltered_aggregations
+    options = {where: {store_id: 2}, aggregations: [:store_id], unfiltered_aggregations: true}
+    assert_equal ({1 => 1, 2 => 2, 3 => 1}), store_bucket_aggregation(options)
   end
 
   protected

--- a/test/aggregations_test.rb
+++ b/test/aggregations_test.rb
@@ -1,5 +1,4 @@
 require_relative "test_helper"
-require "active_support/core_ext"
 
 class TestAggregations < Minitest::Test
 

--- a/test/aggregations_test.rb
+++ b/test/aggregations_test.rb
@@ -1,0 +1,54 @@
+require_relative "test_helper"
+require "active_support/core_ext"
+
+class TestAggregations < Minitest::Test
+
+  def setup
+    super
+    store [
+           {name: "Product Show", latitude: 37.7833, longitude: 12.4167, store_id: 1, in_stock: true, color: "blue", price: 21, created_at: 2.days.ago},
+           {name: "Product Hide", latitude: 29.4167, longitude: -98.5000, store_id: 2, in_stock: false, color: "green", price: 25, created_at: 2.days.from_now},
+           {name: "Product B", latitude: 43.9333, longitude: -122.4667, store_id: 2, in_stock: false, color: "red", price: 5},
+           {name: "Foo", latitude: 43.9333, longitude: 12.4667, store_id: 3, in_stock: false, color: "yellow", price: 15}
+          ]
+  end
+
+  def test_basic
+    assert_equal ({1 => 1, 2 => 2}), store_bucket_aggregation(aggregations: [:store_id])
+  end
+
+  def test_field
+    assert_equal ({1 => 1, 2 => 2}), store_bucket_aggregation(aggregations: {store_id: {}})
+    assert_equal ({1 => 1, 2 => 2}), store_bucket_aggregation(aggregations: {store_id: {field: "store_id"}})
+    assert_equal ({1 => 1, 2 => 2}), store_bucket_aggregation({aggregations: {store_id_new: {field: "store_id"}}}, "store_id_new")
+  end
+
+  def test_ranges
+    price_ranges = [{to: 10}, {from: 10, to: 20}, {from: 20}]
+    aggregation = Product.search("Product", aggregations: {price: {ranges: price_ranges}}).aggregations["price"]
+
+    assert_equal 3, aggregation["buckets"].size
+    assert_equal 10.0, aggregation["buckets"][0]["to"]
+    assert_equal 20.0, aggregation["buckets"][2]["from"]
+    assert_equal 1, aggregation["buckets"][0]["doc_count"]
+    assert_equal 0, aggregation["buckets"][1]["doc_count"]
+    assert_equal 2, aggregation["buckets"][2]["doc_count"]
+  end
+
+  def test_stats
+    options = {where: {store_id: 2}, aggregations: {store_id: {stats: true}}}
+    aggregations = Product.search("Product", options).aggregations["store_id"]
+    expected_aggregations_keys = %w(count min max avg sum)
+    assert_equal expected_aggregations_keys, aggregations.keys
+  end
+
+  def test_smart_aggregations
+    options = {where: {store_id: 2}, aggregations: [:store_id], smart_aggregations: true}
+    assert_equal ({2 => 2}), store_bucket_aggregation(options)
+  end
+
+  protected
+  def store_bucket_aggregation(options, aggregation_key="store_id")
+    Hash[Product.search("Product", options).aggregations[aggregation_key]["buckets"].map { |v| [v["key"], v["doc_count"]] }]
+  end
+end

--- a/test/aggregations_test.rb
+++ b/test/aggregations_test.rb
@@ -26,28 +26,28 @@ class TestAggregations < Minitest::Test
     price_ranges = [{to: 10}, {from: 10, to: 20}, {from: 20}]
     aggregation = Product.search("Product", aggregations: {price: {ranges: price_ranges}}).aggregations["price"]
 
-    assert_equal 3, aggregation["buckets"].size
-    assert_equal 10.0, aggregation["buckets"][0]["to"]
-    assert_equal 20.0, aggregation["buckets"][2]["from"]
-    assert_equal 1, aggregation["buckets"][0]["doc_count"]
-    assert_equal 0, aggregation["buckets"][1]["doc_count"]
-    assert_equal 2, aggregation["buckets"][2]["doc_count"]
+    assert_equal 3, aggregation["ranges"]["buckets"].size
+    assert_equal 10.0, aggregation["ranges"]["buckets"][0]["to"]
+    assert_equal 20.0, aggregation["ranges"]["buckets"][2]["from"]
+    assert_equal 1, aggregation["ranges"]["buckets"][0]["doc_count"]
+    assert_equal 0, aggregation["ranges"]["buckets"][1]["doc_count"]
+    assert_equal 2, aggregation["ranges"]["buckets"][2]["doc_count"]
   end
 
   def test_stats
     options = {where: {store_id: 2}, aggregations: {store_id: {stats: true}}}
-    aggregations = Product.search("Product", options).aggregations["store_id"]
+    aggregations = Product.search("Product", options).aggregations["store_id"]["stats"]
     expected_aggregations_keys = %w(count min max avg sum)
     assert_equal expected_aggregations_keys, aggregations.keys
   end
 
-  def test_unfiltered_aggregations
-    options = {where: {store_id: 2}, aggregations: [:store_id], unfiltered_aggregations: true}
-    assert_equal ({1 => 1, 2 => 2, 3 => 1}), store_bucket_aggregation(options)
+  def test_smart_aggregations
+    options = {where: {store_id: 2}, aggregations: [:store_id], smart_aggregations: true}
+    assert_equal ({1 => 1, 2 => 2}), store_bucket_aggregation(options)
   end
 
   protected
   def store_bucket_aggregation(options, aggregation_key="store_id")
-    Hash[Product.search("Product", options).aggregations[aggregation_key]["buckets"].map { |v| [v["key"], v["doc_count"]] }]
+    Hash[Product.search("Product", options).aggregations[aggregation_key]["terms"]["buckets"].map { |v| [v["key"], v["doc_count"]] }]
   end
 end


### PR DESCRIPTION
since facets are deprecated, and will be substituted for aggregations, i've implemented for the search method, to accept aggregations options, which is very similar to facets.

it would be bad if we lost the searchkick friendly query, making a custom request to get aggregated data (with aggregations instead of facets).

I'll write some docs after considerations