### PR TITLE
Additional support for regular expressions (using strings instead of Regexp object)

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -504,6 +504,8 @@ module Searchkick
                     }
                   }
                 }
+              when :regexp # support for regexp queries without using a regexp ruby object
+                filters << {regexp: {field => {value: op_value}}}
               when :not # not equal
                 filters << {not: term_filters(field, op_value)}
               when :all

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -98,6 +98,11 @@ class TestSql < Minitest::Test
     assert_search "*", ["Product A"], where: {name: /Pro.+/}
   end
 
+  def test_alternate_regexp
+    store_names ["Product A", "Item B"]
+    assert_search "*", ["Product A"], where: {name: {regexp: "Pro.+"}}
+  end
+
   def test_where_string
     store [
       {name: "Product A", color: "RED"}


### PR DESCRIPTION
Currently Regexp Ruby objects aren't serializable using the msgpack gem that we (Instacart) use to serialize objects to pass into InstacartRPC calls. Ideally we'd pass in the query json as a string across the wire, but right now, we're passing the params directly as is.

Currently, the only way to perform a regexp filter query against ES using Searchkick is to use a Regexp Ruby object. This PR changes that and allows someone to perform regexp searches using plain strings.

Where in the past you would have to say:

    {where: {field: /pattern/}}

Now you can say:

    {where: {field: {regexp: "pattern"}}}

Let me know what you think.