### PR TITLE
add multiplier boost

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -167,14 +167,17 @@ module Searchkick
         custom_filters = []
 
         boost_by = options[:boost_by] || {}
+
         if boost_by.is_a?(Array)
-          boost_by = Hash[boost_by.map { |f| [f, {factor: 1}] }]
+          boost_by_sum = Hash[boost_by.map { |f| [f, {factor: 1}] }]
+        elsif boost_by.is_a?(Hash)
+          boost_by_multiply, boost_by_sum = boost_by.partition { |k,v| v[:boost_mode] == "multiply" }.map{|i| Hash[i] }
         end
         if options[:boost]
-          boost_by[options[:boost]] = {factor: 1}
+          boost_by_sum[options[:boost]] = {factor: 1}
         end
 
-        boost_by.each do |field, value|
+        boost_by_sum.each do |field, value|
           script_score =
             if below12
               {script_score: {script: "#{value[:factor].to_f} * log(doc['#{field}'].value + 2.718281828)"}}
@@ -189,6 +192,28 @@ module Searchkick
               }
             }
           }.merge(script_score)
+        end
+
+        if boost_by_multiply
+          multiply_filters = []
+
+          boost_by_multiply.each do |field, value|
+            script_score =
+              if below12
+                {script_score: {script: "#{value[:factor].to_f} * doc['#{field}'].value"}}
+              else
+                value[:factor] ||= 1
+                {field_value_factor: {field: field, factor: value[:factor].to_f}}
+              end
+
+            multiply_filters << {
+              filter: {
+                exists: {
+                  field: field
+                }
+              }
+            }.merge(script_score)
+          end
         end
 
         boost_where = options[:boost_where] || {}
@@ -238,31 +263,7 @@ module Searchkick
           }
         end
 
-        multiply_filters = []
-
-        multiply_by = options[:multiply_by] || {}
-        if multiply_by.is_a?(Array)
-          multiply_by = Hash[multiply_by.map { |f| [f, {factor: 1}] }]
-        end
-
-        multiply_by.each do |field, value|
-          script_score =
-            if below12
-              {script_score: {script: "#{value[:factor].to_f} * doc['#{field}'].value"}}
-            else
-              {field_value_factor: {field: field, factor: value[:factor].to_f}}
-            end
-
-          multiply_filters << {
-            filter: {
-              exists: {
-                field: field
-              }
-            }
-          }.merge(script_score)
-        end
-
-        if multiply_filters.any?
+        if multiply_filters && multiply_filters.any?
           payload = {
             function_score: {
               functions: multiply_filters,

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -108,8 +108,7 @@ class TestBoost < Minitest::Test
       {name: "Tomato C", found_rate: 0.5}
     ]
 
-    assert_order "tomato", ["Tomato B", "Tomato A", "Tomato C"], multiply_by: [:found_rate]
-    assert_order "tomato", ["Tomato B", "Tomato A", "Tomato C"], multiply_by: {found_rate: {factor: 1}}
+    assert_order "tomato", ["Tomato B", "Tomato A", "Tomato C"], boost_by: {found_rate: {factor: 1, boost_mode: "multiply"}}
   end
 
   def test_boost_where

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -101,6 +101,17 @@ class TestBoost < Minitest::Test
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 10}}
   end
 
+  def test_multiply_by
+    store [
+      {name: "Tomato A", found_rate: 0.9},
+      {name: "Tomato B"},
+      {name: "Tomato C", found_rate: 0.5}
+    ]
+
+    assert_order "tomato", ["Tomato B", "Tomato A", "Tomato C"], multiply_by: [:found_rate]
+    assert_order "tomato", ["Tomato B", "Tomato A", "Tomato C"], multiply_by: {found_rate: {factor: 1}}
+  end
+
   def test_boost_where
     store [
       {name: "Tomato A"},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ if defined?(Mongoid)
     field :in_stock, type: Boolean
     field :backordered, type: Boolean
     field :orders_count, type: Integer
+    field :found_rate, type: BigDecimal
     field :price, type: Integer
     field :color
     field :latitude, type: BigDecimal
@@ -90,6 +91,7 @@ elsif defined?(NoBrainer)
     field :in_stock,     type: Boolean
     field :backordered,  type: Boolean
     field :orders_count, type: Integer
+    field :found_rate
     field :price,        type: Integer
     field :color,        type: String
     field :latitude
@@ -135,6 +137,7 @@ else
     t.boolean :in_stock
     t.boolean :backordered
     t.integer :orders_count
+    t.decimal :found_rate
     t.integer :price
     t.string :color
     t.decimal :latitude, precision: 10, scale: 7


### PR DESCRIPTION
thoughts on this @ankane? cc @meetrajesh 

basically ops wants to experiment with lowering scores of results, based on various factors. the current `boost_by` doesn't quite work because it adds up all the function scores, and then multiplies the score by that sum.

i can add to readme, and anything else you suggest, but wanted to run it by you guys first.