### PR TITLE
add support of query_cache param

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -382,6 +382,12 @@ module Searchkick
         if options[:routing]
           @routing = options[:routing]
         end
+
+        # query caching can only be true/false
+        @query_cache = options[:query_cache]
+        unless !!@query_cache == @query_cache
+          @query_cache = nil
+        end
       end
 
       @body = payload
@@ -411,6 +417,7 @@ module Searchkick
       }
       params.merge!(type: @type) if @type
       params.merge!(routing: @routing) if @routing
+      params.merge!(query_cache: @query_cache) unless @query_cache.nil?
       params
     end
 

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -11,4 +11,32 @@ class TestQuery < Minitest::Test
     assert_equal ["Apple", "Milk"], query.execute.map(&:name).sort
   end
 
+  def test_query_cache_true
+    query = Searchkick::Query.new(Product, "*", query_cache: true)
+
+    params = query.params
+
+    assert params[:query_cache]
+  end
+
+  def test_query_cache_false
+    query = Searchkick::Query.new(Product, "*", query_cache: false)
+    params = query.params
+
+    refute params[:query_cache]
+  end
+
+  def test_query_cache_nil
+    # query_cache given as nil
+    query = Searchkick::Query.new(Product, "*", query_cache: nil)
+    assert_nil query.params[:query_cache]
+
+    # query_cache given as non boolean
+    query = Searchkick::Query.new(Product, "*", query_cache: "non boolean value")
+    assert_nil query.params[:query_cache]
+
+    # query_cache not given
+    query = Searchkick::Query.new(Product, "*")
+    assert_nil query.params[:query_cache]
+  end
 end


### PR DESCRIPTION
As I wrote earlier in this issue: https://github.com/ankane/searchkick/issues/482

this PR adds the support to `query_cache` param to be given as either `true` or `false`, any other value is not passed to the `Searchkick.client` and therefore is not taken into account.

the `query_cache` option is very helpful especially for single search query requests, more details can be found here [1]

[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-shard-query-cache.html#_enabling_caching_per_request