### PR TITLE
add bulk update method

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -70,6 +70,16 @@ module Searchkick
       end
     end
 
+    def update(records, fields)
+      records.group_by { |r| document_type(r) }.each do |type, batch|
+        client.bulk(
+          index: name,
+          type: type,
+          body: batch.map { |r| {update: {_id: search_id(r), data: {doc: search_data(r).slice(*fields)}}} }
+        )
+      end
+    end
+
     def retrieve(record)
       client.get(
         index: name,

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -88,6 +88,24 @@ class TestIndex < Minitest::Test
     Product.reindex
   end
 
+  def test_update_color
+    store [{name: "Product A", color: "blue", store_id: 1},
+           {name: "Product B", color: "red", store_id: 3}]
+
+    assert_search "product", [], where: {color: "green"}
+
+    product = Product.where(color: "blue").first
+    product["color"] = "green"
+    product["store_id"] = 5
+    Product.searchkick_index.update([product], ["color"])
+    Product.searchkick_index.refresh
+
+    assert_search "product", ["Product A"], where: {color: "green"}
+    assert_search "product", [], where: {store_id: 5}
+  ensure
+    Product.reindex
+  end
+
   def test_missing_index
     assert_raises(Searchkick::MissingIndexError) { Product.search "test", index_name: "not_found" }
   end


### PR DESCRIPTION
we have a use case where we want to update a single field for a lot of records at a high frequency, and this should increase the number of documents we can send to the bulk endpoint and speed up the indexing process.
