### PR TITLE
Disable cutoff_frequency when misspellings is false

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -96,11 +96,6 @@ module Searchkick
               }
 
               if field == "_all" || field.end_with?(".analyzed")
-                shared_options[:cutoff_frequency] = 0.001 unless operator == "and"
-                qs.concat [
-                  shared_options.merge(boost: 10 * factor, analyzer: "searchkick_search"),
-                  shared_options.merge(boost: 10 * factor, analyzer: "searchkick_search2")
-                ]
                 misspellings = options.key?(:misspellings) ? options[:misspellings] : options[:mispellings] # why not?
                 if misspellings != false
                   edit_distance = (misspellings.is_a?(Hash) && (misspellings[:edit_distance] || misspellings[:distance])) || 1
@@ -110,6 +105,11 @@ module Searchkick
                     shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search2").merge(transpositions)
                   ]
                 end
+                shared_options[:cutoff_frequency] = 0.001 unless operator == "and" || misspellings == false
+                qs.concat [
+                  shared_options.merge(boost: 10 * factor, analyzer: "searchkick_search"),
+                  shared_options.merge(boost: 10 * factor, analyzer: "searchkick_search2")
+                ]
               elsif field.end_with?(".exact")
                 f = field.split(".")[0..-2].join(".")
                 queries << {match: {f => shared_options.merge(analyzer: "keyword")}}

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -244,6 +244,28 @@ class TestSql < Minitest::Test
     assert_search "aaaa", ["aabb"], misspellings: {distance: 2}
   end
 
+  def test_misspellings_fields_operator
+    store [
+      {name: "red", color: "red"},
+      {name: "blue", color: "blue"},
+      {name: "cyan", color: "blue green"},
+      {name: "magenta", color: "red blue"},
+      {name: "green", color: "green"}
+    ]
+    assert_search "red blue", ["red", "blue", "cyan", "magenta"], operator: "or", fields: ["color"], misspellings: false
+  end
+
+  def test_fields_operator
+    store [
+      {name: "red", color: "red"},
+      {name: "blue", color: "blue"},
+      {name: "cyan", color: "blue green"},
+      {name: "magenta", color: "red blue"},
+      {name: "green", color: "green"}
+    ]
+    assert_search "red blue", ["red", "blue", "cyan", "magenta"], operator: "or", fields: ["color"]
+  end
+
   def test_fields
     store [
       {name: "red", color: "light blue"},


### PR DESCRIPTION
When cutoff_frequency is specified with misspellings = false, the high frequency terms are no longer matched against (sort of becomes an "and" query even when operator "or" is specified). 

This is most likely to happen mainly when searching against fields that share similar values e.g a field containing tags associated with the current object.
 
Added a couple of tests for this and opted for disabling cutoff_frequency instead of providing option for user to specify a custom cutoff_frequency.

This might fix #339 as well, not 100% sure without information from the original poster.