### PR TITLE
Add prefix_length option for misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,18 @@ Product.search "mikl", misspellings: {transpositions: true} # milk
 
 This is planned to be the default in Searchkick 1.0.
 
+For short queries, it may be helpful to turn on mispellings after a specified number of letters.
+
+```ruby
+Product.search "api", misspellings: {prefix_length:2} # api, apt, not any
+```
+
+**Note:** If query length is the same as `prefix_length`, misspellings is automatically turned off.
+
+```ruby
+Product.search "ah", misspellings: {prefix_length:2} # ah, not aha
+```
+
 ### Indexing
 
 Control what data is indexed with the `search_data` method. Call `Product.reindex` after changing this method.

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -100,9 +100,10 @@ module Searchkick
                 if misspellings != false
                   edit_distance = (misspellings.is_a?(Hash) && (misspellings[:edit_distance] || misspellings[:distance])) || 1
                   transpositions = (misspellings.is_a?(Hash) && misspellings[:transpositions] == true) ? {fuzzy_transpositions: true} : {}
+                  prefix_length = (misspellings.is_a?(Hash) && misspellings[:prefix_length]) || 0
                   qs.concat [
-                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search").merge(transpositions),
-                    shared_options.merge(fuzziness: edit_distance, max_expansions: 3, analyzer: "searchkick_search2").merge(transpositions)
+                    shared_options.merge(fuzziness: edit_distance, prefix_length: prefix_length, max_expansions: 3, analyzer: "searchkick_search").merge(transpositions),
+                    shared_options.merge(fuzziness: edit_distance, prefix_length: prefix_length, max_expansions: 3, analyzer: "searchkick_search2").merge(transpositions)
                   ]
                 end
                 shared_options[:cutoff_frequency] = 0.001 unless operator == "and" || misspellings == false

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -244,6 +244,18 @@ class TestSql < Minitest::Test
     assert_search "aaaa", ["aabb"], misspellings: {distance: 2}
   end
 
+  def test_misspellings_prefix_length
+    store_names ["ap", "api", "apt", "any", "nap", "ah", "aha"]
+    assert_search "ap", ["ap"], misspellings: {prefix_length: 2}
+    assert_search "api", ["ap", "api", "apt"], misspellings: {prefix_length: 2}
+  end
+
+  def test_misspellings_prefix_length_operator
+    store_names ["ap", "api", "apt", "any", "nap", "ah", "aha"]
+    assert_search "ap ah", ["ap", "ah"], operator: "or", misspellings: {prefix_length: 2}
+    assert_search "api ahi", ["ap", "api", "apt", "ah", "aha"], operator: "or", misspellings: {prefix_length: 2}
+  end
+
   def test_misspellings_fields_operator
     store [
       {name: "red", color: "red"},


### PR DESCRIPTION
Added prefix_length option for misspellings to disable fuzzy matching for short words (keeping prefix_length for lack of a better name).

Main gotcha is when a query term has the same length as prefix_length whereby it becomes an exact match query, hence the extra test case.

This should fix #410, but defaulting prefix_length to 0 if unspecified for backwards compatibility.

Let me know if you want me to submit  PR to update README for this.