### PR TITLE
Searchkick env

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -63,7 +63,7 @@ module Searchkick
   end
 
   def self.env
-    @env ||= ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+    @env ||= ENV["ELASTICSEARCH_ENV"] || ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
   end
 end
 

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,3 @@
 module Searchkick
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,4 @@
 module Searchkick
   VERSION = "0.9.1"
 end
+

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,4 +1,3 @@
 module Searchkick
   VERSION = "0.9.1"
 end
-


### PR DESCRIPTION
In order to use staging and not have to run the local catalog server, it's necessary to tell search that it's pointed at and running on staging. We can set the ELASTICSEARCH_URL to be the staging url, but then we need to also use "staging" as the environment.