### PR TITLE
Add better error message when using smart_facets on facets

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -311,7 +311,7 @@ module Searchkick
             # offset is not possible
             # http://elasticsearch-users.115913.n3.nabble.com/Is-pagination-possible-in-termsStatsFacet-td3422943.html
 
-            facet_options.deep_merge!(where: options[:where].reject { |k| k == field }) if options[:smart_facets] == true
+            facet_options.deep_merge!(where: options.fetch(:where, {}).reject { |k| k == field } ) if options[:smart_facets] == true
             facet_filters = where_filters(facet_options[:where])
             if facet_filters.any?
               payload[:facets][field][:facet_filter] = {


### PR DESCRIPTION
Hi,

I looks like if you use `:facets + smart_facets => true`, searchkick gem will raise an exception.
```ruby
NoMethodError: undefined method `reject' for nil:NilClass
from: .../searchkick-0.9.0/lib/searchkick/query.rb:315
```

Was wondering, is it ok to raise an explicit Exception? or.. Would u rather set a default empty `Hash`?

Cheers,
Kleber
