### PR TITLE
Add date_histogram support

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -297,6 +297,24 @@ module Searchkick
                   size: size
                 }
               }
+            elsif histogram = facet_options[:date_histogram]
+              interval = histogram[:interval]
+              if histogram[:field]
+                payload[:facets][field] = {
+                  date_histogram: {
+                    field: histogram[:field],
+                    interval: interval
+                  }
+                }
+              elsif histogram[:key_field]
+                payload[:facets][field] = {
+                  date_histogram: {
+                    key_field: histogram[:key_field],
+                    value_field: histogram[:value_field],
+                    interval: interval
+                  }
+                }
+              end
             else
               payload[:facets][field] = {
                 terms: {

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -120,8 +120,11 @@ class TestFacets < Minitest::Test
         }
       }
     ).facets
+    entry_attributes = %w(time count min max total total_count mean)
 
-    assert_equal 2, facets["products_per_year"]["entries"].size
+    entries = facets["products_per_year"]["entries"]
+    assert_equal 2, entries.size
+    assert_equal entry_attributes, entries.first.keys
   end
 
   protected

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -83,6 +83,35 @@ class TestFacets < Minitest::Test
     assert_equal expected_facets_keys, facets.first.keys
   end
 
+  # time grouping
+
+  def test_facets_group_by_date
+    store [{name: "Old Product", created_at: 3.years.ago}]
+    facets = Product.search("Product", { facets: { products_per_year: { date_histogram: { field: :created_at, interval: :year }}}}).facets
+
+    assert_equal 2, facets["products_per_year"]["entries"].size
+  end
+
+  def test_facets_group_by_date_with_value_field
+    store [{name: "Old Product", created_at: 3.years.ago, price: 100}]
+    facets = Product.search(
+      "Product",
+      {
+        facets: {
+          products_per_year: {
+            date_histogram: {
+              key_field: :created_at,
+              value_field: :price,
+              interval: :year
+            }
+          }
+        }
+      }
+    ).facets
+
+    assert_equal 2, facets["products_per_year"]["entries"].size
+  end
+
   protected
 
   def store_facet(options, facet_key="store_id")

--- a/test/facets_test.rb
+++ b/test/facets_test.rb
@@ -87,7 +87,19 @@ class TestFacets < Minitest::Test
 
   def test_facets_group_by_date
     store [{name: "Old Product", created_at: 3.years.ago}]
-    facets = Product.search("Product", { facets: { products_per_year: { date_histogram: { field: :created_at, interval: :year }}}}).facets
+    facets = Product.search(
+      "Product",
+      {
+        facets: {
+          products_per_year: {
+            date_histogram: {
+              field: :created_at,
+              interval: :year
+            }
+          }
+        }
+      }
+    ).facets
 
     assert_equal 2, facets["products_per_year"]["entries"].size
   end


### PR DESCRIPTION
I added date_histogram support, [here's ES's doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-date-histogram-facet.html).

**Normal version:**
Usage:
```
    Product.search(
      "Product",
      {
        facets: {
          products_per_year: {
            date_histogram: {
              field: :created_at,
              interval: :year
            }
          }
        }
      }
    )
```
Facets output:
```
{"products_per_year"=>
  {"_type"=>"date_histogram",
   "entries"=>
    [{"time"=>1325376000000, "count"=>1}, {"time"=>1420070400000, "count"=>3}]
  }
}
```

**And also the `value field` version:**

Usage:
```
    Product.search(
      "Product",
      {
        facets: {
          products_per_year: {
            date_histogram: {
              key_field: :created_at,
              value_field: :price,
              interval: :year
            }
          }
        }
      }
    )
```
Facets output:
```
{"products_per_year"=>
  {"_type"=>"date_histogram",
   "entries"=>
    [{"time"=>1325376000000,
      "count"=>1,
      "min"=>100.0,
      "max"=>100.0,
      "total"=>100.0,
      "total_count"=>1,
      "mean"=>100.0},
     {"time"=>1420070400000,
      "count"=>3,
      "min"=>5.0,
      "max"=>25.0,
      "total"=>51.0,
      "total_count"=>3,
      "mean"=>17.0}]
     }
   }
 }
```