### PR TITLE
Add support for aggregations

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -75,6 +75,17 @@ module Searchkick
       response["facets"]
     end
 
+    def aggs
+      response["aggregations"].each do |field, filtered_agg|
+        buckets = filtered_agg[field]
+        # move the buckets one level above into the field hash
+        if buckets
+          filtered_agg.delete(field)
+          filtered_agg.merge!(buckets)
+        end
+      end
+    end
+
     def took
       response["took"]
     end

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -1,0 +1,77 @@
+require_relative "test_helper"
+require "active_support/core_ext"
+
+class TestAggs < Minitest::Test
+
+  def setup
+    super
+    store [
+      {name: "Product Show", latitude: 37.7833, longitude: 12.4167, store_id: 1, in_stock: true, color: "blue", price: 21, created_at: 2.days.ago},
+      {name: "Product Hide", latitude: 29.4167, longitude: -98.5000, store_id: 2, in_stock: false, color: "green", price: 25, created_at: 2.days.from_now},
+      {name: "Product B", latitude: 43.9333, longitude: -122.4667, store_id: 2, in_stock: false, color: "red", price: 5},
+      {name: "Foo", latitude: 43.9333, longitude: 12.4667, store_id: 3, in_stock: false, color: "yellow", price: 15}
+    ]
+  end
+
+  def test_basic
+    assert_equal ({1 => 1, 2 => 2}), store_agg(aggs: [:store_id])
+  end
+
+  def test_where
+    assert_equal ({1 => 1}), store_agg(aggs: {store_id: {where: {in_stock: true}}})
+  end
+
+  def test_field
+    assert_equal ({1 => 1, 2 => 2}), store_agg(aggs: {store_id: {}})
+    assert_equal ({1 => 1, 2 => 2}), store_agg(aggs: {store_id: {field: "store_id"}})
+    assert_equal ({1 => 1, 2 => 2}), store_agg({aggs: {store_id_new: {field: "store_id"}}}, "store_id_new")
+  end
+
+  def test_where_no_smart_aggs
+    assert_equal ({2 => 2}), store_agg(where: {color: "red"}, aggs: {store_id: {where: {in_stock: false}}})
+    assert_equal ({2 => 2}), store_agg(where: {color: "blue"}, aggs: {store_id: {where: {in_stock: false}}})
+  end
+
+  def test_smart_aggs
+    assert_equal ({1 => 1}), store_agg(where: {in_stock: true}, aggs: [:store_id], smart_aggs: true)
+  end
+
+  def test_smart_aggs_where
+    assert_equal ({2 => 1}), store_agg(where: {color: "red"}, aggs: {store_id: {where: {in_stock: false}}}, smart_aggs: true)
+  end
+
+  def test_smart_aggs_where_override
+    assert_equal ({2 => 1}), store_agg(where: {color: "red"}, aggs: {store_id: {where: {in_stock: false, color: "blue"}}}, smart_aggs: true)
+    assert_equal ({}), store_agg(where: {color: "blue"}, aggs: {store_id: {where: {in_stock: false, color: "red"}}}, smart_aggs: true)
+  end
+
+  def test_smart_aggs_skip_agg
+    assert_equal ({1 => 1, 2 => 2}), store_agg(where: {store_id: 2}, aggs: [:store_id], smart_aggs: true)
+  end
+
+  def test_smart_aggs_skip_agg_complex
+    assert_equal ({1 => 1, 2 => 1}), store_agg(where: {store_id: 2, price: {gt: 5}}, aggs: [:store_id], smart_aggs: true)
+  end
+
+  def test_multiple_aggs
+    assert_equal ({"store_id" => {1 => 1, 2 => 2}, "color" => {"blue" => 1, "green" => 1, "red" => 1}}), store_multiple_aggs(aggs: [:store_id, :color])
+  end
+
+  protected
+
+  def buckets_as_hash(agg)
+    agg["buckets"].map { |v| [v["key"], v["doc_count"]] }.to_h
+  end
+
+  def store_agg(options, agg_key = "store_id")
+    buckets = Product.search("Product", options).aggs[agg_key]
+    buckets_as_hash(buckets)
+  end
+
+  def store_multiple_aggs(options)
+    Product.search("Product", options).aggs.map do |field, filtered_agg|
+      [field, buckets_as_hash(filtered_agg)]
+    end.to_h
+  end
+
+end


### PR DESCRIPTION
This PR adds support for aggregations to searchkick as an alternative to facets. Moreover, since facets will be [removed](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/_removed_features.html) from Elasticsearch as of v2.0, people who were previously using facets in searchkick will need to move to aggregations if they want to use it with ES v2.0.

This PR attempts to keep the aggregations behavior as similar as possible to facets so people will not have to change too much code when migrating their searchkick clients.

I went back and forth between "aggs" and "aggregations" in the code (elasticsearch supports both), and eventually opted for "aggs" everywhere for standardization and also because "aggregations" is more typo-prone.

The searchkick query looks like this:

`Product.search("Product", aggs: {store_id: {where: {in_stock: true}}})`

which generates an ES query payload that looks like this:

```
{
   "query": {
   },
   "size":10,
   "from":0,
   "aggs": {
      "store_id": {
         "filter": {
            "bool": {
               "must": [
                  {
                     "term": {
                        "in_stock": true
                     }
                  }
               ]
            }
         },
         "aggs": {
            "store_id": {
               "terms": {
                  "field": "store_id"
               }
            }
         }
      }
   }
}
```

which produces an ES response that looks like this:

```
{
   "store_id": {
      "doc_count": 1,
      "store_id": {
         "doc_count_error_upper_bound": 0,
         "sum_other_doc_count": 0,
         "buckets": [
            {
               "key": 1,
               "doc_count": 1
            }
         ]
      }
   }
}
```

Calling `response.aggs` (i.e. `Product.search(...).aggs`) returns a hash that looks like:

```
{
   "store_id": {
      "doc_count": 1,
      "doc_count_error_upper_bound": 0,
      "sum_other_doc_count": 0,
      "buckets": [
         {
            "key": 1,
            "doc_count": 1
         }
      ]
   }
}
```

