### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Call `Product.reindex` after changing synonyms.
 
 ### WordNet
 
-Prepopulate English synonyms with the [WordNet database](http://en.wikipedia.org/wiki/WordNet).
+Prepopulate English synonyms with the [WordNet database](https://en.wikipedia.org/wiki/WordNet).
 
 Download [WordNet 3.0](http://wordnetcode.princeton.edu/3.0/WNprolog-3.0.tar.gz) to each Elasticsearch server and move `wn_s.pl` to the `/var/lib` directory.
 
@@ -301,7 +301,7 @@ end
 
 ### Misspellings
 
-By default, Searchkick handles misspelled queries by returning results with an [edit distance](http://en.wikipedia.org/wiki/Levenshtein_distance) of one.
+By default, Searchkick handles misspelled queries by returning results with an [edit distance](https://en.wikipedia.org/wiki/Levenshtein_distance) of one.
 
 You can change this with:
 
@@ -893,7 +893,7 @@ Searchkick uses `ENV["ELASTICSEARCH_URL"]` for the Elasticsearch server.  This d
 
 ### Heroku
 
-Choose an add-on: [SearchBox](https://addons.heroku.com/searchbox), [Bonsai](https://addons.heroku.com/bonsai), or [Found](https://addons.heroku.com/foundelasticsearch).
+Choose an add-on: [SearchBox](https://elements.heroku.com/addons/searchbox), [Bonsai](https://elements.heroku.com/addons/bonsai), or [Found](https://addons.heroku.com/foundelasticsearch).
 
 ```sh
 # SearchBox
@@ -1318,7 +1318,7 @@ For convenience, this is set by default in the test environment.
 
 ## Thanks
 
-Thanks to Karel Minarik for [Elasticsearch Ruby](https://github.com/elasticsearch/elasticsearch-ruby) and [Tire](https://github.com/karmi/tire), Jaroslav Kalistsuk for [zero downtime reindexing](https://gist.github.com/jarosan/3124884), and Alex Leschenko for [Elasticsearch autocomplete](https://github.com/leschenko/elasticsearch_autocomplete).
+Thanks to Karel Minarik for [Elasticsearch Ruby](https://github.com/elasticsearch/elasticsearch-ruby) and [Tire](https://github.com/karmi/retire), Jaroslav Kalistsuk for [zero downtime reindexing](https://gist.github.com/jarosan/3124884), and Alex Leschenko for [Elasticsearch autocomplete](https://github.com/leschenko/elasticsearch_autocomplete).
 
 ## Roadmap
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/karmi/tire | https://github.com/karmi/retire 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://en.wikipedia.org/wiki/Levenshtein_distance | https://en.wikipedia.org/wiki/Levenshtein_distance 
http://en.wikipedia.org/wiki/WordNet | https://en.wikipedia.org/wiki/WordNet 
https://addons.heroku.com/bonsai | https://elements.heroku.com/addons/bonsai 
https://addons.heroku.com/searchbox | https://elements.heroku.com/addons/searchbox 
