### PR TITLE
Reverse pin location when passed as array.

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -705,7 +705,8 @@ module Searchkick
             location = (
               sort[:_geo_distance][:location]  ||
               sort[:_geo_distance][:"pin.location"]
-            )
+            )                                  &&
+            location.is_a?(Array)
 
           location.reverse!
         end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -371,10 +371,8 @@ module Searchkick
         payload[:explain] = options[:explain] if options[:explain]
 
         # order
-        if options[:order]
-          order = options[:order].is_a?(Enumerable) ? options[:order] : {options[:order] => :asc}
-          # TODO id transformation for arrays
-          payload[:sort] = order.is_a?(Array) ? order : Hash[order.map { |k, v| [k.to_s == "id" ? :_id : k, v] }]
+        if order = options[:order]
+          payload[:sort] = sort_fields(order)
         end
 
         # filters
@@ -696,6 +694,29 @@ module Searchkick
             }
           }
         }.merge(script_score)
+      end
+    end
+
+    def sort_fields(order)
+      order            = order.is_a?(Enumerable) ? order : {order => :asc}
+      reverse_location = ->(sort) {
+        if  sort.is_a?(Hash)                   &&
+            sort[:_geo_distance]               &&
+            location = (
+              sort[:_geo_distance][:location]  ||
+              sort[:_geo_distance][:"pin.location"]
+            )
+
+          location.reverse!
+        end
+      }
+
+      # TODO id transformation for arrays
+      if order.is_a?(Array)
+        order.each(&reverse_location)
+      else
+        Hash[order.map { |k, v| [k.to_s == "id" ? :_id : k, v] }].
+          tap(&reverse_location)
       end
     end
 


### PR DESCRIPTION
Hi there,

I came across this possible bug today. _I wouldn't say bug, it's more for an improvement._

Problem: When sorting via `_geo_distance_` we have the flexibility to pass the lat and lon as a array as well as Hash as we do in the `where` section.

```ruby
{
  :_geo_distance: { location: [-114, 23] } 
  # or
  :_geo_distance: { location: {lat: 23, lon: -114} } 
  # or
  :_geo_distance: { :"pin.location" => {lat: 23, lon: -144} } 
}
```
Right?

My proposal is, as the `where` section takes care of that for us for example [here](https://github.com/ankane/searchkick/blob/master/lib/searchkick/query.rb#L602), [here](https://github.com/ankane/searchkick/blob/master/lib/searchkick/query.rb#L610) and [here](https://github.com/ankane/searchkick/blob/master/lib/searchkick/query.rb#L611) the developer will assume that the same it's being done in the `sort` section.

