### PR TITLE
Problems reindexing when using Oj

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -101,11 +101,16 @@ module Searchkick
   # private
   def self.perform_items(items)
     if items.any?
+      if defined?(Oj)
+        oj_options = Oj.default_options
+        Oj.default_options = { :indent => 0 }
+      end
       response = client.bulk(body: items)
       if response["errors"]
         first_item = response["items"].first
         raise Searchkick::ImportError, (first_item["index"] || first_item["delete"])["error"]
       end
+      Oj.default_options = oj_options if defined?(Oj)
     end
   end
 

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -96,7 +96,8 @@ module Searchkick
         if defined?(Searchkick::ReindexV2Job)
           Searchkick::ReindexV2Job.perform_later(record.class.name, record.id.to_s)
         else
-          Delayed::Job.enqueue Searchkick::ReindexJob.new(record.class.name, record.id.to_s)
+          # Delayed::Job.enqueue Searchkick::ReindexJob.new(record.class.name, record.id.to_s)
+          reindex_record(record)
         end
       else
         reindex_record(record)

--- a/searchkick.gemspec
+++ b/searchkick.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "oj"
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -33,4 +33,16 @@ class ModelTest < Minitest::Test
 
     assert_search "product", ["product a", "product b"]
   end
+
+  def test_with_oj_options
+    Oj.default_options = { :indent => 2 }
+    test_disable_callbacks_model
+    Oj.default_options = { :indent => 0 }
+  end
+
+  def test_disable_callbacks_global_with_oj
+    Oj.default_options = { :indent => 2 }
+    test_disable_callbacks_global
+    Oj.default_options = { :indent => 0 }
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 require "minitest/pride"
 require "logger"
 require "active_support/core_ext" if defined?(NoBrainer)
+require 'oj'
 
 ENV["RACK_ENV"] = "test"
 


### PR DESCRIPTION
I was using searchkick in a project and had just introduced `Oj` to help optimize and format JSON output. After running my test suite I ran into the following error with a model that was using `reindex`:

`Elasticsearch::Transport::Transport::Errors::BadRequest: [400] {"error":"Unexpected end-of-input.. }`
After further investigation I found this to occur during most other model methods and was not limited to reindex (search, index, callbacks, etc)

It turns out someone else had reported nearly the exact same issue back in May 2014 (#196). In that Issue the OP is content with removing Oj config and have things work as expected.. 
>Turns out the culprit was a single line problem in a Rabl config file that we had put in at one point while trying to debug another situation.
> 
> Oj.default_options = Oj.default_options.merge({indent: 2})
Removed the line, removed the problem. Love a simple solution!

Unfortunately for us removing that config was not an option...

I propose a solution for all Oj  users; which would ensure their options are usable as is by having the `indent` option set to its default state (0) and then switching back to the users settings after processing (and all transport) is completing.

Open to suggestions to the testing as it does seem a bit invasive (introducing `oj` dependency, etc)