### PR TITLE
add option for number of replicas

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -343,6 +343,10 @@ module Searchkick
         if options[:similarity]
           settings[:similarity] = {default: {type: options[:similarity]}}
         end
+        
+        if options[:number_of_replicas]
+          settings.merge!(number_of_replicas: options[:number_of_replicas])
+        end
 
         settings.deep_merge!(options[:settings] || {})
 


### PR DESCRIPTION
Added this option because Heroku Bonsai tiers limit number of shards you can have, and because I may or may not care about failovers.