### PR TITLE
Allow new way of selecting source fields

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -73,7 +73,7 @@ module Searchkick
         callback_name = callbacks == :async ? :reindex_async : :reindex
         if respond_to?(:after_commit)
           after_commit callback_name, if: proc { self.class.search_callbacks? }
-        else
+        elsif respond_to?(:after_save)
           after_save callback_name, if: proc { self.class.search_callbacks? }
           after_destroy callback_name, if: proc { self.class.search_callbacks? }
         end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -567,10 +567,19 @@ module Searchkick
         end
 
         # An empty array will cause only the _id and _type for each hit to be returned
-        # http://www.elasticsearch.org/guide/reference/api/search/fields/
+        # doc for :select - http://www.elasticsearch.org/guide/reference/api/search/fields/
+        # doc for :source_select - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
         if options[:select]
           payload[:fields] = options[:select] if options[:select] != true
+        elsif options[:source_select]
+          if options[:source_select] == []
+            # intuitively [] makes sense to return no fields, but ES by default returns all fields
+            payload[:fields] = []
+          else
+            payload[:_source] = options[:source_select]
+          end
         elsif load
+          # don't need any fields since we're going to load them from the DB anyways
           payload[:fields] = []
         end
 
@@ -650,7 +659,7 @@ module Searchkick
                   when :lte
                     {to: op_value, include_upper: true}
                   else
-                    raise "Unknown where operator"
+                    raise "Unknown where operator: #{op.inspect}"
                   end
                 # issue 132
                 if (existing = filters.find { |f| f[:range] && f[:range][field] })

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -39,8 +39,10 @@ module Searchkick
             result =
               if hit["_source"]
                 hit.except("_source").merge(hit["_source"])
-              else
+              elsif hit["fields"]
                 hit.except("fields").merge(hit["fields"])
+              else
+                hit
               end
 
             if hit["highlight"]

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -81,6 +81,7 @@ class SqlTest < Minitest::Test
     result = Product.search("product", load: false, select: [:name, :store_id]).first
     assert_equal %w(id name store_id), result.keys.reject { |k| k.start_with?("_") }.sort
     assert_equal ["Product A"], result.name # this is not great
+    assert_equal [1], result.store_id # this isn't great either
   end
 
   def test_select_array
@@ -89,12 +90,65 @@ class SqlTest < Minitest::Test
     assert_equal [1, 2], result.user_ids
   end
 
+  def test_select_single_field
+    store [{name: "Product A", store_id: 1}]
+    result = Product.search("product", load: false, select: :name).first
+    assert_equal %w(id name), result.keys.reject { |k| k.start_with?("_") }.sort
+    assert_equal ["Product A"], result.name
+    assert_equal nil, result.store_id
+  end
+
   def test_select_all
     store [{name: "Product A", user_ids: [1, 2]}]
     hit = Product.search("product", select: true).hits.first
     assert_equal hit["_source"]["name"], "Product A"
     assert_equal hit["_source"]["user_ids"], [1, 2]
   end
+
+  def test_select_none
+    store [{name: "Product A", user_ids: [1, 2]}]
+    hit = Product.search("product", select: []).hits.first
+    assert_equal hit["_source"], nil
+  end
+
+  # source_select
+
+  def test_source_select
+    store [{name: "Product A", store_id: 1}]
+    result = Product.search("product", load: false, source_select: [:name, :store_id]).first
+    assert_equal %w(id name store_id), result.keys.reject { |k| k.start_with?("_") }.sort
+    assert_equal "Product A", result.name
+    assert_equal 1, result.store_id
+  end
+
+  def test_source_select_array
+    store [{name: "Product A", user_ids: [1, 2]}]
+    result = Product.search("product", load: false, source_select: [:user_ids]).first
+    assert_equal [1, 2], result.user_ids
+  end
+
+  def test_source_select_single_field
+    store [{name: "Product A", store_id: 1}]
+    result = Product.search("product", load: false, source_select: :name).first
+    assert_equal %w(id name), result.keys.reject { |k| k.start_with?("_") }.sort
+    assert_equal "Product A", result.name
+    assert_equal nil, result.store_id
+  end
+
+  def test_source_select_all
+    store [{name: "Product A", user_ids: [1, 2]}]
+    hit = Product.search("product", source_select: true).hits.first
+    assert_equal hit["_source"]["name"], "Product A"
+    assert_equal hit["_source"]["user_ids"], [1, 2]
+  end
+
+  def test_source_select_none
+    store [{name: "Product A", user_ids: [1, 2]}]
+    hit = Product.search("product", source_select: []).hits.first
+    assert_equal hit["_source"], nil
+  end
+
+  # other tests
 
   def test_nested_object
     aisle = {"id" => 1, "name" => "Frozen"}


### PR DESCRIPTION
**Problem**: The old way of selecting a subset of source fields was to use `select:` in the search options which maps to `fields:` in the ES query body. This had two major problems:

1. You can only select leaf nodes
2. Results were returned as an array regardless of how they're originally stored in the document (*really* annoying)

The new way of selecting subset of source fields is to use the `_source` option in the search payload: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html

The new way fixes the limitations of the old way, while adding a few new cool features:

1. You can now select non-leaf-nodes
2. You can now add wildcards within the object tree, eg. `obj.*`, `obj1.*`, etc. The old feature only operated on leaf nodes so this wasn't needed.
3. You can specify both `include` and `exclude` patterns. Previously you could only specify a whitelist (include), but not a blacklist (exclude). This allows a user to select all fields _except_ 3 specified fields, for example.

This PR introduces a new option called `source_select` that behaves mostly like `select` but uses the new ES source selection implementation.

The only difference between this PR's implementation and the documented `_source:` feature is that I've changed `source_select: []` to return no source fields to match the existing `select: []` behavior. The default elasticsearch behavior for `_source: []` is to return _all_ fields, similar to `select: true`, or no select at all.

`source_select: true` returns all fields. This is the default ES behavior of `_source: true`.