### PR TITLE
More select_v2 tests

### DIFF
--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -146,6 +146,33 @@ class SqlTest < Minitest::Test
     store [{name: "Product A", user_ids: [1, 2]}]
     hit = Product.search("product", select_v2: []).hits.first
     assert_nil hit["_source"]
+    hit = Product.search("product", select_v2: false).hits.first
+    assert_nil hit["_source"]
+  end
+
+  def test_select_v2_include
+    store [{name: "Product A", user_ids: [1, 2]}]
+    result = Product.search("product", load: false, select_v2: {include: [:name]}).first
+    assert_equal %w(id name), result.keys.reject { |k| k.start_with?("_") }.sort
+    assert_equal "Product A", result.name
+    assert_nil result.store_id
+  end
+
+  def test_select_v2_exclude
+    store [{name: "Product A", user_ids: [1, 2], store_id: 1}]
+    result = Product.search("product", load: false, select_v2: {exclude: [:name]}).first
+    assert_nil result.name
+    assert_equal [1, 2], result.user_ids
+    assert_equal 1, result.store_id
+  end
+
+  def test_select_v2_include_and_exclude
+    # let's take this to the next level
+    store [{name: "Product A", user_ids: [1, 2], store_id: 1}]
+    result = Product.search("product", load: false, select_v2: {include: [:store_id], exclude: [:name]}).first
+    assert_equal 1, result.store_id
+    assert_nil result.name
+    assert_nil result.user_ids
   end
 
   # other tests


### PR DESCRIPTION
In summary:

`select_v2: true` should return all source fields
`select_v2: false` should return no source fields (i.e. the `_source` key should go missing)
`select_v2: []` should return no source fields (i.e. the `_source` key should go missing)
`select_v2: [:a, :b, :c]` should return just those 3 source fields
`select_v2: :a` should return just :a
`select_v2: {include: [:a, :b, :c]}` should return just those 3 source fields
`select_v2: {exclude: [:c]}` should return everything but :c
`select_v2: {include: [:a], exclude: [:c]}` should only return :a
