### PR TITLE
Recommend touch: true for "cache-busting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,17 +428,11 @@ end
 
 #### Associations
 
-Data is **not** automatically synced when an association is updated.  If this is desired, add a callback to reindex:
+Data is **not** automatically synced when an association is updated.  If this is desired, be sure to include a `touch` option to your association to ensure that an ActiveRecord update is triggered when the associated record is changed to allow it to be reindexed:
 
 ```ruby
 class Image < ActiveRecord::Base
-  belongs_to :product
-
-  after_commit :reindex_product
-
-  def reindex_product
-    product.reindex # or reindex_async
-  end
+  belongs_to :product, touch: true
 end
 ```
 


### PR DESCRIPTION
The README here suggests using ActiveRecord callbacks to trigger a reindex on an association update. It seems like it'd be much cleaner if you just used the `touch` option, which updates the parent record's `updated_at` timestamp when the child object is changed.

P.S. HUGE fan of this gem. Thank you for authoring it!
