### PR TITLE
Add require statement to signed request example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,6 +964,7 @@ gem 'faraday_middleware-aws-signers-v4'
 and add to your initializer:
 
 ```ruby
+require "faraday_middleware/aws_signers_v4"
 Searchkick.client =
   Elasticsearch::Client.new(
     url: ENV["ELASTICSEARCH_URL"],


### PR DESCRIPTION
Without this require, I was getting

```
/var/bundle/ruby/2.3.0/gems/faraday-0.9.2/lib/faraday.rb:189:in `lookup_middleware': :aws_signers_v4 is not registered on Faraday::Request (Faraday::Error)
```