### PR TITLE
Add Support for min_doc_count Filter in Aggregations Query with Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 *.log
 .DS_Store
 .ruby-*
+.idea/

--- a/README.md
+++ b/README.md
@@ -624,6 +624,13 @@ Limit
 Product.search "apples", aggs: {store_id: {limit: 10}}
 ```
 
+Minimum Document Count
+
+```ruby
+Product.search "apples", aggs: {store_id: {min_doc_count: 2}}
+# Only return stores that have 2 or more hits
+```
+
 Order
 
 ```ruby

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -527,7 +527,7 @@ module Searchkick
 
       aggs.each do |field, agg_options|
         size = agg_options[:limit] ? agg_options[:limit] : 1_000
-        shared_agg_options = agg_options.slice(:order)
+        shared_agg_options = agg_options.slice(:order, :min_doc_count)
 
         if agg_options[:ranges]
           payload[:aggs][field] = {

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -30,6 +30,10 @@ class AggsTest < Minitest::Test
     assert_equal ({1 => 1, 2 => 2}), store_agg({aggs: {store_id_new: {field: "store_id"}}}, "store_id_new")
   end
 
+  def test_min_doc_count
+    assert_equal ({2 => 2}), store_agg(aggs: {store_id: { min_doc_count: 2 }})
+  end
+
   def test_no_aggs
     assert_nil Product.search("*").aggs
   end


### PR DESCRIPTION
Added support for this very useful ES feature: 

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_minimum_document_count_3

It allows users to change the minimum number of hits required for results to be returned in aggregations. 

Why is it important? Consider this SQL to find duplicate names:

`select count(*) from products group by name having count(*) >= 2`

With this PR you can now do this:

`Product.search "*", aggs: {name: {min_doc_count: 2}}`
