### PR TITLE
[WIP] Records order preservation ActiveRecord POC

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -17,10 +17,15 @@ module Searchkick
 
     # experimental: may not make next release
     def records
-      @order_by ||= hits.map do |hit|
-        "#{klass.table_name}.#{klass.primary_key}='#{hit['_id']}' DESC"
-      end.join(", ")
-      @records ||= results_query(klass, hits).reorder(@order_by)
+      @records ||= results_query(klass, hits)
+      # Handle order preservation in ActiveRecord
+      if @records.respond_to?(:primary_key) && @records.primary_key
+        @order_by ||= hits.map do |hit|
+          "#{klass.table_name}.#{klass.primary_key}='#{hit['_id']}' DESC"
+        end.join(", ")
+        @records = @records.reorder(@order_by)
+      end
+      @records
     end
 
     def results

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -17,7 +17,10 @@ module Searchkick
 
     # experimental: may not make next release
     def records
-      @records ||= results_query(klass, hits)
+      @order_by ||= hits.map do |hit|
+        "#{klass.table_name}.#{klass.primary_key}='#{hit['_id']}' DESC"
+      end.join(", ")
+      @records ||= results_query(klass, hits).reorder(@order_by)
     end
 
     def results

--- a/test/records_test.rb
+++ b/test/records_test.rb
@@ -1,8 +1,9 @@
 require_relative "test_helper"
 
 class RecordsTest < Minitest::Test
-  def test_records
-    store_names ["Milk", "Apple"]
-    assert_equal Product.search("milk").records.where(name: "Milk").count, 1
+  def test_records_preserves_order
+    store_names ["Milk 1", "Milk 2", "Apple"]
+    # search("milk 2") will match "Milk 2" first, and "Milk 1" second
+    assert_equal Product.search("milk 2").records.where('name LIKE "%Milk%"').map(&:name), ['Milk 2', 'Milk 1']
   end
 end


### PR DESCRIPTION
Fixes #463 

As you know, currently the `records` method is not ordered by Elasticsearch's `hit` ordering. Taking heavy inspiration from `order_as_specified` gem, this preserves the order of the search results.

It should be noted that this is _quite_ slow to do, and should only be done if you **really** need an `ActiveRecord::Relation`. Otherwise, it's possibly better to just use the existing in-memory representation.
#### Todo
- [ ] Ensure compatibility with all ActiveRecord DBs (MySQL, PostgreSQL, SQLite, etc)
- [ ] Ensure that the existing `results_query` preserves order for Mongoid/NoBrainer

Let me know if you have any thoughts.

also, cc @abevoelker @milushov 
