### PR TITLE
reindexing models on an ES cluster that is totally new / empty throws…

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -36,7 +36,7 @@ module Searchkick
         begin
           client.indices.get_alias(name: name).keys
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
-          []
+          {}
         end
       actions = old_indices.map { |old_name| {remove: {index: old_name, alias: name}} } + [{add: {index: new_name, alias: name}}]
       client.indices.update_aliases body: {actions: actions}
@@ -146,7 +146,7 @@ module Searchkick
         begin
           client.indices.get_aliases
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
-          []
+          {}
         end
       indices = all_indices.select { |k, v| (v.empty? || v["aliases"].empty?) && k =~ /\A#{Regexp.escape(name)}_\d{14,17}\z/ }.keys
       indices.each do |index|


### PR DESCRIPTION
… the following exception:

irb(main):001:0> User.reindex

NoMethodError: undefined method `keys' for []:Array
	from /app/vendor/bundle/ruby/2.1.0/gems/searchkick-1.2.1/lib/searchkick/index.rb:151:in `clean_indices'
	from /app/vendor/bundle/ruby/2.1.0/gems/searchkick-1.2.1/lib/searchkick/index.rb:163:in `reindex_scope'
	from /app/vendor/bundle/ruby/2.1.0/gems/searchkick-1.2.1/lib/searchkick/model.rb:51:in `searchkick_reindex'
	from (irb):1
	from /app/vendor/bundle/ruby/2.1.0/gems/railties-4.0.4/lib/rails/commands/console.rb:90:in `start'
	from /app/vendor/bundle/ruby/2.1.0/gems/railties-4.0.4/lib/rails/commands/console.rb:9:in `start'
	from /app/vendor/bundle/ruby/2.1.0/gems/railties-4.0.4/lib/rails/commands.rb:62:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'

When I looked into it, client.indices.get_alias returns a hash, not an array, so the NotFound rescue should be returning an empty hash.  This change fixes the issue.

I did NOT add a unit test because the only way to test this would be to either nuke all indexes from the local ES test cluster, or startup a totally vanilla cluster just for running the test, which is kind of out of the scope of this change.