### PR TITLE
Add min_score option and tests

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -158,6 +158,7 @@ module Searchkick
       per_page = (options[:limit] || options[:per_page] || 1_000).to_i
       padding = [options[:padding].to_i, 0].max
       offset = options[:offset] || (page - 1) * per_page + padding
+      min_score = options[:min_score] || 0.0
 
       # model and eagar loading
       load = options[:load].nil? ? true : options[:load]
@@ -342,7 +343,8 @@ module Searchkick
         payload = {
           query: payload,
           size: per_page,
-          from: offset
+          from: offset,
+          min_score: min_score
         }
         payload[:explain] = options[:explain] if options[:explain]
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -158,7 +158,6 @@ module Searchkick
       per_page = (options[:limit] || options[:per_page] || 1_000).to_i
       padding = [options[:padding].to_i, 0].max
       offset = options[:offset] || (page - 1) * per_page + padding
-      min_score = options[:min_score] || 0.0
 
       # model and eagar loading
       load = options[:load].nil? ? true : options[:load]
@@ -343,8 +342,7 @@ module Searchkick
         payload = {
           query: payload,
           size: per_page,
-          from: offset,
-          min_score: min_score
+          from: offset
         }
         payload[:explain] = options[:explain] if options[:explain]
 
@@ -393,6 +391,9 @@ module Searchkick
         # routing
         @routing = options[:routing] if options[:routing]
       end
+
+      # merge more body options
+      payload = payload.deep_merge(options[:body_options]) if options[:body_options]
 
       @body = payload
       @facet_limits = @facet_limits || {}

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -10,4 +10,14 @@ class QueryTest < Minitest::Test
     assert_equal ["Apple", "Milk"], query.map(&:name).sort
     assert_equal ["Apple", "Milk"], query.execute.map(&:name).sort
   end
+
+  def test_with_effective_min_score
+    store_names ["Milk", "Milk2"]
+    assert_equal ["Milk"], Product.search("Milk", min_score: 0.1).map(&:name)
+  end
+
+  def test_with_uneffective_min_score
+    store_names ["Milk", "Milk2"]
+    assert_equal ["Milk", "Milk2"], Product.search("Milk", min_score: 0.0001).map(&:name)
+  end
 end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -13,11 +13,11 @@ class QueryTest < Minitest::Test
 
   def test_with_effective_min_score
     store_names ["Milk", "Milk2"]
-    assert_equal ["Milk"], Product.search("Milk", min_score: 0.1).map(&:name)
+    assert_equal ["Milk"], Product.search("Milk", body_options: { min_score: 0.1 }).map(&:name)
   end
 
   def test_with_uneffective_min_score
     store_names ["Milk", "Milk2"]
-    assert_equal ["Milk", "Milk2"], Product.search("Milk", min_score: 0.0001).map(&:name)
+    assert_equal ["Milk", "Milk2"], Product.search("Milk", body_options: { min_score: 0.0001 }).map(&:name)
   end
 end

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -52,15 +52,10 @@ class SqlTest < Minitest::Test
     assert_search "product", ["Product"], where: {latitude: {gt: 79}}
   end
 
-  # min_score
+  # body_options
 
-  def test_min_score_default_to_zero
-    query = Product.search("milk", execute: false)
-    assert_equal 0.0, query.body[:min_score]
-  end
-
-  def test_should_use_min_score_param
-    query = Product.search({ query: { name: "milk"}, min_score: 1.0 }, execute: false)
+  def test_body_options_should_merge_into_body
+    query = Product.search({ query: { name: "milk"}, body_options: { min_score: 1.0 }}, execute: false)
     assert_equal 1.0, query.body[:min_score]
   end
 

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -52,6 +52,18 @@ class SqlTest < Minitest::Test
     assert_search "product", ["Product"], where: {latitude: {gt: 79}}
   end
 
+  # min_score
+
+  def test_min_score_default_to_zero
+    query = Product.search("milk", execute: false)
+    assert_equal 0.0, query.body[:min_score]
+  end
+
+  def test_should_use_min_score_param
+    query = Product.search({ query: { name: "milk"}, min_score: 1.0 }, execute: false)
+    assert_equal 1.0, query.body[:min_score]
+  end
+
   # load
 
   def test_load_default


### PR DESCRIPTION
Hi @ankane 

It's been a while that PRs related to `min_score`(https://github.com/ankane/searchkick/pull/292, https://github.com/ankane/searchkick/pull/492) not being merged. I guess that's because the deprecated facets and missing tests makes you labeled `waiting`, so I just extracted `min_score` option part from PRs and had rebased master already. Thanks to @sebfie and @st0012, hope this small feature could be merged.