### PR TITLE
Async reindex jobs have a potential race condition

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Andrew Kane
+Copyright (c) 2013-2016 Andrew Kane
 
 MIT License
 


### PR DESCRIPTION
Hello,

If you have 2 records that get updated in rapid succession and you run the searchkick async reindexer, there is a small chance that the reindex uses old data. Example:
1. record gets updated `name: 'foo'`
2. async reindex gets queued and job runs, but there is some sort of network delay
3. record gets updated `name: 'bar'`
4. async reindex gets queued and job runs and completes _first_
5. job from (2) completes _second_ and now the record's index has `name: 'foo'`, when it should be `name: 'bar'`

To prevent this, I wrote a "queue" with a mutex which counts the number of active jobs that want to index the same record (identified by `"#{klass}::{id}"`). The queue itself contains Mutex instances such that when many jobs are acting on a single record, it basically runs them serial to prevent the above situation.

I don't know if this is the best solution, so looking for feedback and ideas. If you accept this PR I will write the tests for it. Speaking of tests, is there a special command to run `ReindexV2JobTest`? I know it's because `ActiveJob` isn't defined, but not sure how to run it correctly.
