### PR TITLE
Support not filter match option

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -736,7 +736,7 @@ module Searchkick
         {missing: {"field" => field, existence: true, null_value: true}}
       elsif value.is_a?(Regexp)
         {regexp: {field => {value: value.source}}}
-      elsif value.is_a?(Hash)
+      elsif value.is_a?(Hash) && below20?
         op, value = value.shift
         {op => {field => value}}
       else

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -736,6 +736,9 @@ module Searchkick
         {missing: {"field" => field, existence: true, null_value: true}}
       elsif value.is_a?(Regexp)
         {regexp: {field => {value: value.source}}}
+      elsif value.is_a?(Hash)
+        op, value = value.shift
+        {op => {field => value}}
       else
         {term: {field => value}}
       end

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -60,6 +60,15 @@ class WhereTest < Minitest::Test
     assert_search "product", ["Product A"], where: {color: "RED"}
   end
 
+  def test_where_not_string
+    store [
+      {name: "Product A"},
+    ]
+    assert_search "product", ["Product A"], where: {"name.analyzed" => {not: "Product"}}
+    assert_search "product", [], where: {"name.analyzed" => {not: "product"}}
+    assert_search "product", [], where: {"name.analyzed" => {not: {match: "Product"}}}
+  end
+
   def test_where_nil
     store [
       {name: "Product A"},

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -61,6 +61,7 @@ class WhereTest < Minitest::Test
   end
 
   def test_where_not_string
+    skip unless elasticsearch2?
     store [
       {name: "Product A"},
     ]


### PR DESCRIPTION

Support not filter match option.
I expect not filter use analyzed word.

For example, ignore the case of characters in searches.