### PR TITLE
Maintain ordering of records from ES response

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ order: {_score: :desc} # most relevant first - default
 
 [All of these sort options are supported](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html)
 
+Using PostgreSQL? Are your records out of order?
+
+When requesting records from a postgresql database, the records are not in the same order that they were returned from ElasticSearch. In order to make this work and perform well, you will need to implement a sorting function at the database level. This is an example function in postgresql:
+
+```sql
+create or replace function find_in_array(needle anyelement, haystack anyarray) returns integer as $$
+declare i integer;
+begin
+  for i in 1..array_upper(haystack, 1) loop
+    if haystack[i] = needle then
+      return i;
+    end if;
+  end loop;
+  raise exception 'find_in_array: % not found in %', needle, haystack;
+end;
+$$ language 'plpgsql';
+```
+
+Once you've defined this function in your database, you just need to tell Searchkick to use it:
+
+```ruby
+Searchkick.db_sorting_function = 'find_in_array'
+```
+
 Limit / offset
 
 ```ruby

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -28,13 +28,14 @@ module Searchkick
   class ImportError < Error; end
 
   class << self
-    attr_accessor :search_method_name, :wordnet_path, :timeout, :models
+    attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :db_sorting_function
     attr_writer :client, :env, :search_timeout
   end
   self.search_method_name = :search
   self.wordnet_path = "/var/lib/wn_s.pl"
   self.timeout = 10
   self.models = []
+  self.db_sorting_function = nil
 
   def self.client
     @client ||=

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -195,7 +195,7 @@ module Searchkick
           # See the link for a more in-depth description
           # https://www.chrissearle.org/2014/05/02/postgresql-sort-where-id-in-by-original-id-list-order/
           records.where(records.primary_key => ids)
-                 .reorder("#{Searchkick.db_sorting_function}(id, #{postgres_array(ids)})")
+                 .reorder("#{Searchkick.db_sorting_function}(#{@klass.table_name}.id, #{postgres_array(ids)})")
         else
           records.where(records.primary_key => ids)
         end

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -176,7 +176,7 @@ module Searchkick
     private
 
     def results_query(records, hits)
-      ids = hits.map { |hit| hit["_id"] }
+      ids = hits.map { |hit| hit['_id'] }
 
       if options[:includes]
         records =
@@ -189,7 +189,16 @@ module Searchkick
 
       if records.respond_to?(:primary_key) && records.primary_key
         # ActiveRecord
-        records.where(records.primary_key => ids)
+        if Searchkick.db_sorting_function
+          # Since PostgreSQL doesn't return records in the same order as the
+          # ElasticSearch query, we use a database function to do so.
+          # See the link for a more in-depth description
+          # https://www.chrissearle.org/2014/05/02/postgresql-sort-where-id-in-by-original-id-list-order/
+          records.where(records.primary_key => ids)
+                 .reorder("#{Searchkick.db_sorting_function}(id, #{postgres_array(ids)})")
+        else
+          records.where(records.primary_key => ids)
+        end
       elsif records.respond_to?(:all) && records.all.respond_to?(:for_ids)
         # Mongoid 2
         records.all.for_ids(ids)
@@ -200,12 +209,23 @@ module Searchkick
         # Nobrainer
         records.unscoped.where(:id.in => ids)
       else
-        raise "Not sure how to load records"
+        raise 'Not sure how to load records'
       end
     end
 
     def base_field(k)
       k.sub(/\.(analyzed|word_start|word_middle|word_end|text_start|text_middle|text_end|exact)\z/, "")
+    end
+
+    def postgres_sql_escape(str)
+      str.gsub(/[%_'\\"]/, "\\\\\\0")
+    end
+
+    def postgres_array(arry)
+      "'{" + arry.inject([]) do |mem, val|
+        mem << (val.is_a?(String) ? "\"#{postgres_sql_escape(val)}\"" : val)
+        mem
+      end.join(", ") + "}'"
     end
   end
 end


### PR DESCRIPTION
I questioned whether or not I should submit a PR for this, but it seems like there are lots of people having the same issue where the records you get from Searchkick::Results are not in the same order that ElasticSearch responded with.

Based on my small amount of testing, the solution is performant and the only drawback is that you must define a db function if you're using Postgres. I've included an example postgresql function in the readme.
