### PR TITLE
Support conversion boosting on multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,34 @@ class Product < ActiveRecord::Base
 end
 ```
 
+Multiple conversion fields
+
+```ruby
+class Product < ActiveRecord::Base
+  has_many :searches, class_name: "Searchjoy::Search"
+
+  # searchkick also supports multiple "conversions" fields
+  searchkick conversions: ["unique_user_conversions", "total_conversions"]
+
+  def search_data
+    {
+      name: name,
+      unique_user_conversions: searches.group(:query).uniq.count(:user_id)
+      # {"ice cream" => 234, "chocolate" => 67, "cream" => 2}
+      total_conversions: searches.group(:query).count
+      # {"ice cream" => 412, "chocolate" => 117, "cream" => 6}
+    }
+  end
+end
+```
+and during query time:
+
+```ruby
+Product.search("banana") # boost by both fields (default)
+Product.search("banana", {conversions: "total_conversions"}) # only boost by total_conversions
+Product.search("banana", {conversions: false}) # no conversion boosting
+```
+
 Change timeout
 
 ```ruby

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -430,7 +430,7 @@ module Searchkick
         mapping = {}
 
         # conversions
-        if (conversions_field = options[:conversions])
+        Array(options[:conversions]).each do |conversions_field|
           mapping[conversions_field] = {
             type: "nested",
             properties: {
@@ -602,9 +602,10 @@ module Searchkick
       source = source.inject({}) { |memo, (k, v)| memo[k.to_s] = v; memo }.except("_id")
 
       # conversions
-      conversions_field = options[:conversions]
-      if conversions_field && source[conversions_field]
-        source[conversions_field] = source[conversions_field].map { |k, v| {query: k, count: v} }
+      Array(options[:conversions]).each do |conversions_field|
+        if source[conversions_field]
+          source[conversions_field] = source[conversions_field].map { |k, v| {query: k, count: v} }
+        end
       end
 
       # hack to prevent generator field doesn't exist error

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -10,6 +10,24 @@ class BoostTest < Minitest::Test
       {name: "Tomato C", conversions: {"tomato" => 3}}
     ]
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"]
+    assert_equal_scores "tomato", {conversions: false}
+  end
+
+  def test_multiple_conversions
+    skip if elasticsearch_below14?
+
+    store [
+      {name: "Speaker A", conversions_a: {"speaker" => 1}, conversions_b: {"speaker" => 6}},
+      {name: "Speaker B", conversions_a: {"speaker" => 2}, conversions_b: {"speaker" => 5}},
+      {name: "Speaker C", conversions_a: {"speaker" => 3}, conversions_b: {"speaker" => 4}},
+    ], Speaker
+
+    assert_equal_scores "speaker", {conversions: false}, Speaker
+    assert_equal_scores "speaker", {}, Speaker
+    assert_equal_scores "speaker", {conversions: ["conversions_a", "conversions_b"]}, Speaker
+    assert_equal_scores "speaker", {conversions: ["conversions_b", "conversions_a"]}, Speaker
+    assert_order "speaker", ["Speaker C", "Speaker B", "Speaker A"], {conversions: "conversions_a"}, Speaker
+    assert_order "speaker", ["Speaker A", "Speaker B", "Speaker C"], {conversions: "conversions_b"}, Speaker
   end
 
   def test_conversions_stemmed


### PR DESCRIPTION
We want to be able to a/b test different scoring mechanisms for conversion boosting. Right now it's not possible to specify the conversions field dynamically at query-time. It can only be specified in the options hash when initializing Searchkick.

This PR changes that and allows the query to overwrite the conversions field that is used to boost records.

```
class Product < ActiveRecord::Base
  has_many :searches, class_name: "Searchjoy::Search"

  searchkick conversions: ["unique_user_conversions", "total_conversions"]

  def search_data
    {
      name: name,
      unique_user_conversions: searches.group(:query).uniq.count(:user_id)
      # {"ice cream" => 234, "chocolate" => 67, "cream" => 2}
      total_conversions: searches.group(:query).count
      # {"ice cream" => 412, "chocolate" => 117, "cream" => 6}
    }
  end
end
```

At query time, you can choose to boost by both fields (default), just one of them, or none of them:

```
Product.search("banana", {conversions: "total_conversions"}) # only boost by total_conversions
Product.search("banana", {conversions: false}) # no conversion boosting
```

cc: @ankane