### PR TITLE
Silent test warnings

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -40,7 +40,7 @@ module Searchkick
     @client ||=
       Elasticsearch::Client.new(
         url: ENV["ELASTICSEARCH_URL"],
-        transport_options: {request: {timeout: timeout}}
+        transport_options: {request: {timeout: timeout}, headers: { content_type: 'application/json' }}
       ) do |f|
         f.use Searchkick::Middleware
       end

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -515,7 +515,7 @@ module Searchkick
               }
             elsif fields[field]
               fields[field].merge(fields: fields.except(field))
-           end
+            end
         end
 
         (options[:locations] || []).map(&:to_s).each do |field|

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -29,6 +29,7 @@ module Searchkick
       @term = term
       @options = options
       @match_suffix = options[:match] || searchkick_options[:match] || "analyzed"
+      @type = @routing = @misspellings_below = @highlighted_fields = nil
 
       prepare
     end
@@ -400,7 +401,7 @@ module Searchkick
       payload = payload.deep_merge(options[:body_options]) if options[:body_options]
 
       @body = payload
-      @facet_limits = @facet_limits || {}
+      @facet_limits ||= {}
       @page = page
       @per_page = per_page
       @padding = padding
@@ -752,8 +753,8 @@ module Searchkick
                   filters << {bool: {must_not: term_filters(field, op_value)}}
                 end
               when :all
-                op_value.each do |value|
-                  filters << term_filters(field, value)
+                op_value.each do |val|
+                  filters << term_filters(field, val)
                 end
               when :in
                 filters << term_filters(field, op_value)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -12,7 +12,7 @@ class ErrorsTest < Minitest::Test
       }
     }
     index.store valid_dog
-    error = assert_raises(Searchkick::ImportError) do
+    assert_raises(Searchkick::ImportError) do
       index.bulk_index [valid_dog, invalid_dog]
     end
   end


### PR DESCRIPTION
When I ran the tests I was flawed with warnings, mainly because of Elasticsearch gem not setting the content-type header.