### PR TITLE
Added `Searchkick::Model#searchkick_indexed_fields` to get which fields are indexed for a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.5 [unreleased]
 
+- Added `Searchkick::Model#searchkick_indexed_fields` to get which fields are indexed for a model
 - Added support for Elasticsearch 5.0 beta
 - Added `request_params` option
 - Added `filterable` option

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Product.search "🍨🍰", emoji: true
 ### Indexing
 
 Control what data is indexed with the `search_data` method. Call `Product.reindex` after changing this method.
+Call `Product.indexed_fields` to find out which fields are indexed for a model. In this case, it will return `[:name, :department_name, :on_sale]`.
 
 ```ruby
 class Product < ActiveRecord::Base

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -69,6 +69,11 @@ module Searchkick
           def searchkick_index_options
             searchkick_index.index_options
           end
+
+          def searchkick_indexed_fields
+            new.search_data.keys.map(&:to_sym)
+          end
+          alias_method :indexed_fields, :searchkick_indexed_fields unless method_defined?(:indexed_fields)
         end
         extend Searchkick::Reindex # legacy for Searchjoy
 

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -39,4 +39,10 @@ class ModelTest < Minitest::Test
     store_names ["Product B"], Store
     assert_equal Product.all + Store.all, Searchkick.search("product", index_name: [Product, Store], order: "name").to_a
   end
+
+  def test_disable_callbacks_model
+    attribute_names = Animal.attribute_names rescue Animal.fields.keys
+    attributes_to_expect = attribute_names - ["_type", "type"]
+    assert_equal Animal.searchkick_indexed_fields, attributes_to_expect.map(&:to_sym)
+  end
 end


### PR DESCRIPTION
Imagine you are in you controller and want to get the fields to list in a dropdown for example. There was no way to achieve that.
