### PR TITLE
Ability to set "distance_type" when using geo_distance filter

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -741,6 +741,8 @@ module Searchkick
               case op
               when :within, :bottom_right, :distance_type
                 # do nothing
+              when :script
+                filters << {script: value}
               when :near
                 geo_distance = {
                     field => location_value(op_value),

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -690,15 +690,15 @@ module Searchkick
           if value.is_a?(Hash)
             value.each do |op, op_value|
               case op
-              when :within, :bottom_right
+              when :within, :bottom_right, :distance_type
                 # do nothing
               when :near
-                filters << {
-                  geo_distance: {
+                geo_distance = {
                     field => location_value(op_value),
-                    distance: value[:within] || "50mi"
-                  }
+                    distance: value[:within] || "50mi",
                 }
+                geo_distance[:distance_type] = value[:distance_type] if value[:distance_type]
+                filters << {geo_distance: geo_distance}
               when :top_left
                 filters << {
                   geo_bounding_box: {


### PR DESCRIPTION
This commit enables to set "distance_type" in the following way:
`location: {near: {lat: 37, lon: -114}, within: '1000km', distance_type: :plane}`
