### PR TITLE
Add partial_reindex instance method

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -101,6 +101,12 @@ module Searchkick
           self.class.searchkick_index.reindex_record_async(self)
         end unless method_defined?(:reindex_async)
 
+        def partial_reindex(method_name)
+          self.class.searchkick_index.bulk_update([self], method_name)
+          self.class.searchkick_index.refresh
+          true
+        end unless method_defined?(:partial_reindex)
+
         def similar(options = {})
           self.class.searchkick_index.similar_record(self, options)
         end unless method_defined?(:similar)

--- a/test/partial_reindex_test.rb
+++ b/test/partial_reindex_test.rb
@@ -9,8 +9,7 @@ class PartialReindexTest < Minitest::Test
     assert_search "blue", ["Hi"], fields: [:color], load: false
 
     # update
-    Product.first.update_column :name, "Bye"
-    Product.first.update_column :color, "Red"
+    Product.first.update_columns(name: "Bye", color: "Red")
     Product.searchkick_index.refresh
 
     # index not updated
@@ -19,6 +18,29 @@ class PartialReindexTest < Minitest::Test
 
     # partial reindex
     Product.partial_reindex(:search_name)
+
+    # name updated, but not color
+    assert_search "bye", ["Bye"], fields: [:name], load: false
+    assert_search "blue", ["Bye"], fields: [:color], load: false
+  end
+
+  def test_with_instance_method
+    store [{name: "Hi", color: "Blue"}]
+
+    # normal search
+    assert_search "hi", ["Hi"], fields: [:name], load: false
+    assert_search "blue", ["Hi"], fields: [:color], load: false
+
+    # update
+    product = Product.first
+    product.update_columns(name: "Bye", color: "Red")
+    Product.searchkick_index.refresh
+
+    # index not updated
+    assert_search "hi", ["Hi"], fields: [:name], load: false
+    assert_search "blue", ["Hi"], fields: [:color], load: false
+
+    product.partial_reindex(:search_name)
 
     # name updated, but not color
     assert_search "bye", ["Bye"], fields: [:name], load: false


### PR DESCRIPTION
Reindex subsets of a particular record
```ruby
class Product
  def search_pricing
    {
      price: price
    }
  end
end
#
product = Product.first
product.partial_reindex(:search_pricing)
```
