### PR TITLE
Add option to customise ignore_above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,14 +1116,6 @@ class Product < ActiveRecord::Base
 end
 ```
 
-By default, if you are using Elasticsearch 2.2 or above fields above `256` charaters are ignored in `where` statements and exact matches. To customize this settings modify the `ignore_above` setting:
-
-```ruby
-class Product < ActiveRecord::Base
-  searchkick ignore_above: 1000 # max = 32766
-end
-```
-
 ### Advanced Search
 
 And use the `body` option to search:

--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,14 @@ class Product < ActiveRecord::Base
 end
 ```
 
+By default, if you are using Elasticsearch 2.2 or above fields above `256` charaters are ignored. To customize this settings modify the `ignore_above` setting:
+
+```ruby
+class Product < ActiveRecord::Base
+  searchkick ignore_above: 1000 # max = 32766
+end
+```
+
 ### Advanced Search
 
 And use the `body` option to search:

--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ class Product < ActiveRecord::Base
 end
 ```
 
-By default, if you are using Elasticsearch 2.2 or above fields above `256` charaters are ignored. To customize this settings modify the `ignore_above` setting:
+By default, if you are using Elasticsearch 2.2 or above fields above `256` charaters are ignored in `where` statements and exact matches. To customize this settings modify the `ignore_above` setting:
 
 ```ruby
 class Product < ActiveRecord::Base

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -25,7 +25,7 @@ module Searchkick
             }
           end
 
-        keyword_mapping[:ignore_above] = 256 unless below22
+        keyword_mapping[:ignore_above] = (options[:ignore_above] || 256) unless below22
 
         settings = {
           analysis: {
@@ -308,7 +308,7 @@ module Searchkick
           dynamic_fields["{name}"] = {type: default_type, index: "no"}
         end
 
-        dynamic_fields["{name}"][:ignore_above] = 256 unless below22
+        dynamic_fields["{name}"][:ignore_above] = (options[:ignore_above] || 256) unless below22
 
         unless options[:searchable]
           if options[:match] && options[:match] != :word


### PR DESCRIPTION
As discussed in #728, `256` charters is quite restrictive and falls far short of the max of `32766` imposed by Elasticsearch. 

This commit adds the ability to customize the 256 characters. 