### PR TITLE
Handle update errors

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -112,7 +112,7 @@ module Searchkick
       response = client.bulk(body: items)
       if response["errors"]
         first_with_error = response["items"].map do |item|
-          (item["index"] || item["delete"])
+          (item["index"] || item["delete"] || item['update'])
         end.find { |item| item["error"] }
         raise Searchkick::ImportError, "#{first_with_error["error"]} on item with id '#{first_with_error["_id"]}'"
       end


### PR DESCRIPTION
Hi,

I recently had an `NoMethodError: undefined method '[]' for nil:NilClass` error being raised when trying to update a document.  After some digging, I noticed searchkick wasn't mapping update errors. 

Should it?
