### PR TITLE
geo_shape support in index and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,8 +836,6 @@ product.similar(fields: ["name"], where: {size: "12 oz"})
 
 ### Geospatial Searches
 
-If your data consists of point values, searchkick offers a useful shorthand:
-
 ```ruby
 class City < ActiveRecord::Base
   searchkick locations: ["location"]
@@ -848,9 +846,7 @@ class City < ActiveRecord::Base
 end
 ```
 
-Elasticsearch supports a range of useful search types for geo_point data:
-
-Within a radius
+Reindex and search with:
 
 ```ruby
 City.search "san", where: {location: {near: {lat: 37, lon: -114}, within: "100mi"}} # or 160km
@@ -881,7 +877,6 @@ Also supports [additional options](https://www.elastic.co/guide/en/elasticsearch
 ```ruby
 City.search "san", boost_by_distance: {field: :location, origin: {lat: 37, lon: -122}, function: :linear, scale: "30mi", decay: 0.5}
 ```
-
 
 ### Geo Shapes
 

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ Any geospatial data type can be used in the index or in the search. It is up to 
 
 See the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html) for details. GeoJSON coordinates are usually given as an array of `[lon, lat]` points but this often causes swapping errors so searchkick can also take objects with `lon` and `lat` keys.
 
-Elasticsearch is sensitive about geo_shape validity. For example it will throw an exception if a polygon contains two consecutive identical points, or is not properly closed. You probably want to validate the data during indexing.
+Elasticsearch is sensitive about geo_shape validity. For example it will throw an exception if a polygon contains two consecutive identical points, intersects itself or is not properly closed.
 
 
 ### Geospatial searching

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -281,6 +281,11 @@ module Searchkick
           }
         end
 
+        options[:geo_shapes] = options[:geo_shapes].product([{}]).to_h if options[:geo_shapes].is_a? Array
+        (options[:geo_shapes] || {}).each do |field, shape_options|
+          mapping[field] = shape_options.merge(type: "geo_shape")
+        end
+
         (options[:unsearchable] || []).map(&:to_s).each do |field|
           mapping[field] = {
             type: default_type,

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -809,15 +809,7 @@ module Searchkick
                   }
                 }
               when :geo_shape
-                if op_value[:type] == "envelope" && op_value[:top_left].present? && op_value[:bottom_right].present?
-                  op_value[:coordinates] = [coordinate_array(op_value[:top_left]), coordinate_array(op_value[:bottom_right])]
-                  op_value.delete(:top_left)
-                  op_value.delete(:bottom_right)
-                elsif op_value[:type] == "circle"
-                  op_value[:coordinates] = coordinate_array(op_value[:coordinates] || [])
-                else
-                  op_value[:coordinates] = (op_value[:coordinates] || []).map { |loc| coordinate_array(loc) }
-                end
+                op_value[:coordinates] = coordinate_array(op_value[:coordinates]) if op_value[:coordinates]
                 relation = op_value.delete(:relation) || 'intersects'
                 filters << {
                   geo_shape: {
@@ -943,9 +935,7 @@ module Searchkick
     end
 
     # Recursively descend through nesting of arrays until we reach either a lat/lon object or an array of numbers,
-    # eventually returning the same structure with all values transformed to [lon, lat]. Question: should we reverse
-    # the array order so that arguments can be given as [lat, lon], as happens elsewhere in searchkick? We are moving
-    # GeoJSON around so it seems better to stick to that specification, though the lat/lon objects are already a deviation.
+    # eventually returning the same structure with all values transformed to [lon, lat].
     #
     def coordinate_array(value)
       if value.is_a?(Hash)

--- a/test/geo_shape_test.rb
+++ b/test/geo_shape_test.rb
@@ -1,0 +1,143 @@
+require "pp"
+require_relative "test_helper"
+
+class GeoShapeTest < Minitest::Test
+
+  def test_geo_shape
+    regions = [
+      {name: "Region A", text: "The witch had a cat", territory: "30,40,35,45,40,40,40,30,30,30,30,40"},
+      {name: "Region B", text: "and a very tall hat", territory: "50,60,55,65,60,60,60,50,50,50,50,60"},
+      {name: "Region C", text: "and long ginger hair which she wore in a plait.",  territory: "10,20,15,25,20,20,20,10,10,10,10,20"},
+    ]
+    store regions, Region
+
+    # circle
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "circle",
+            coordinates: {lat: 28.0, lon: 38.0},
+            radius: "444000m"
+          }
+        }
+      }
+    }, Region
+
+    # envelope
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            coordinates: [[28, 42], [32, 38]]
+          }
+        }
+      }
+    }, Region
+
+    # envelope as corners
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            top_left: {lat: 42.0, lon: 28.0},
+            bottom_right: {lat: 38.0, lon: 32.0}
+          }
+        }
+      }
+    }, Region
+
+    # polygon
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "polygon",
+            coordinates: [[[38, 42], [42, 42], [42, 38], [38, 38], [38, 42]]]
+          }
+        }
+      }
+    }, Region
+
+    # multipolygon
+    assert_search "*", ["Region A", "Region B"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "multipolygon",
+            coordinates: [
+              [[[38, 42], [42, 42], [42, 38], [38, 38], [38, 42]]],
+              [[[58, 62], [62, 62], [62, 58], [58, 58], [58, 62]]]
+            ]
+          }
+        }
+      }
+    }, Region
+
+    # disjoint
+    assert_search "*", ["Region B", "Region C"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            relation: "disjoint",
+            coordinates: [[28, 42], [32, 38]]
+          }
+        }
+      }
+    }, Region
+
+    # within
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            relation: "within",
+            coordinates: [[20, 50], [50, 20]]
+          }
+        }
+      }
+    }, Region
+
+    # contains
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            relation: "contains",
+            coordinates: [[32, 33], [33, 32]]
+          }
+        }
+      }
+    }, Region
+
+    # with search
+    assert_search "witch", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            coordinates: [[28, 42], [32, 38]]
+          }
+        }
+      }
+    }, Region
+
+    assert_search "ginger hair", [], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            coordinates: [[28, 42], [32, 38]]
+          }
+        }
+      }
+    }, Region
+
+  end
+
+end

--- a/test/geo_shape_test.rb
+++ b/test/geo_shape_test.rb
@@ -1,17 +1,16 @@
-require "pp"
 require_relative "test_helper"
 
 class GeoShapeTest < Minitest::Test
-
-  def test_geo_shape
-    regions = [
+  def setup
+    super
+    store [
       {name: "Region A", text: "The witch had a cat", territory: "30,40,35,45,40,40,40,30,30,30,30,40"},
       {name: "Region B", text: "and a very tall hat", territory: "50,60,55,65,60,60,60,50,50,50,50,60"},
-      {name: "Region C", text: "and long ginger hair which she wore in a plait.",  territory: "10,20,15,25,20,20,20,10,10,10,10,20"},
-    ]
-    store regions, Region
+      {name: "Region C", text: "and long ginger hair which she wore in a plait",  territory: "10,20,15,25,20,20,20,10,10,10,10,20"}
+    ], Region
+  end
 
-    # circle
+  def test_circle
     assert_search "*", ["Region A"], {
       where: {
         territory: {
@@ -23,8 +22,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # envelope
+  def test_envelope
     assert_search "*", ["Region A"], {
       where: {
         territory: {
@@ -35,21 +35,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # envelope as corners
-    assert_search "*", ["Region A"], {
-      where: {
-        territory: {
-          geo_shape: {
-            type: "envelope",
-            top_left: {lat: 42.0, lon: 28.0},
-            bottom_right: {lat: 38.0, lon: 32.0}
-          }
-        }
-      }
-    }, Region
-
-    # polygon
+  def test_polygon
     assert_search "*", ["Region A"], {
       where: {
         territory: {
@@ -60,8 +48,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # multipolygon
+  def test_multipolygon
     assert_search "*", ["Region A", "Region B"], {
       where: {
         territory: {
@@ -75,8 +64,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # disjoint
+  def test_disjoint
     assert_search "*", ["Region B", "Region C"], {
       where: {
         territory: {
@@ -88,8 +78,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # within
+  def test_within
     assert_search "*", ["Region A"], {
       where: {
         territory: {
@@ -101,8 +92,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
-    # with search
+  def test_search_math
     assert_search "witch", ["Region A"], {
       where: {
         territory: {
@@ -113,7 +105,9 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
+  end
 
+  def test_search_no_match
     assert_search "ginger hair", [], {
       where: {
         territory: {
@@ -126,20 +120,18 @@ class GeoShapeTest < Minitest::Test
     }, Region
   end
 
-  def test_geo_shape_contains
+  def test_contains
     skip if elasticsearch_below22?
-
-    assert_search "*", ["Region A"], {
+    assert_search "*", ["Region C"], {
       where: {
         territory: {
           geo_shape: {
             type: "envelope",
             relation: "contains",
-            coordinates: [[32, 33], [33, 32]]
+            coordinates: [[12, 13], [13,12]]
           }
         }
       }
     }, Region
-
   end
 end

--- a/test/geo_shape_test.rb
+++ b/test/geo_shape_test.rb
@@ -102,19 +102,6 @@ class GeoShapeTest < Minitest::Test
       }
     }, Region
 
-    # contains
-    assert_search "*", ["Region A"], {
-      where: {
-        territory: {
-          geo_shape: {
-            type: "envelope",
-            relation: "contains",
-            coordinates: [[32, 33], [33, 32]]
-          }
-        }
-      }
-    }, Region
-
     # with search
     assert_search "witch", ["Region A"], {
       where: {
@@ -137,7 +124,22 @@ class GeoShapeTest < Minitest::Test
         }
       }
     }, Region
-
   end
 
+  def test_geo_shape_contains
+    skip if elasticsearch_below22?
+
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            relation: "contains",
+            coordinates: [[32, 33], [33, 32]]
+          }
+        }
+      }
+    }, Region
+
+  end
 end

--- a/test/geo_shape_test.rb
+++ b/test/geo_shape_test.rb
@@ -4,9 +4,30 @@ class GeoShapeTest < Minitest::Test
   def setup
     super
     store [
-      {name: "Region A", text: "The witch had a cat", territory: "30,40,35,45,40,40,40,30,30,30,30,40"},
-      {name: "Region B", text: "and a very tall hat", territory: "50,60,55,65,60,60,60,50,50,50,50,60"},
-      {name: "Region C", text: "and long ginger hair which she wore in a plait",  territory: "10,20,15,25,20,20,20,10,10,10,10,20"}
+      {
+        name: "Region A",
+        text: "The witch had a cat",
+        territory: {
+          type: "polygon",
+          coordinates: [[[30,40],[35,45],[40,40],[40,30],[30,30],[30,40]]]
+        }
+      },
+      {
+        name: "Region B",
+        text: "and a very tall hat",
+        territory: {
+          type: "polygon",
+          coordinates: [[[50,60],[55,65],[60,60],[60,50],[50,50],[50,60]]]
+        }
+      },
+      {
+        name: "Region C",
+        text: "and long ginger hair which she wore in a plait",
+        territory: {
+          type: "polygon",
+          coordinates: [[[10,20],[15,25],[20,20],[20,10],[10,10],[10,20]]]
+        }
+      }
     ], Region
   end
 
@@ -87,7 +108,7 @@ class GeoShapeTest < Minitest::Test
           geo_shape: {
             type: "envelope",
             relation: "within",
-            coordinates: [[20, 50], [50, 20]]
+            coordinates: [[20,50], [50,20]]
           }
         }
       }
@@ -134,4 +155,18 @@ class GeoShapeTest < Minitest::Test
       }
     }, Region
   end
+
+  def test_latlon
+    assert_search "*", ["Region A"], {
+      where: {
+        territory: {
+          geo_shape: {
+            type: "envelope",
+            coordinates: [{lat: 42, lon: 28}, {lat: 38, lon: 32}]
+          }
+        }
+      }
+    }, Region
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,10 @@ def elasticsearch_below50?
   Searchkick.server_below?("5.0.0-alpha1")
 end
 
+def elasticsearch_below22?
+  Searchkick.server_below?("2.2.0")
+end
+
 def elasticsearch_below20?
   Searchkick.server_below?("2.0.0")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,7 +102,6 @@ if defined?(Mongoid)
 
     field :name
     field :text
-    field :territory
   end
 
   class Speaker
@@ -161,7 +160,6 @@ elsif defined?(NoBrainer)
     field :id,   type: Object
     field :name, type: String
     field :text, type: Text
-    field :territory, type: Text
   end
 
   class Speaker
@@ -258,7 +256,6 @@ else
   ActiveRecord::Migration.create_table :regions do |t|
     t.string :name
     t.text :text
-    t.text :territory
   end
 
   ActiveRecord::Migration.create_table :speakers do |t|
@@ -374,24 +371,14 @@ class Region
       territory: {tree: "quadtree", precision: "10km"}
     }
 
+  attr_accessor :territory
+
   def search_data
     {
       name: name,
       text: text,
-      territory: as_geo_json
+      territory: territory
     }
-  end
-
-  def as_geo_json
-    {
-      type: "polygon",
-      coordinates: [territory_path] # enclosing array because polygon can also have exclusion paths.
-    }
-  end
-
-  def territory_path
-    path = territory.split(',').map(&:to_f).each_slice(2).to_a
-    path
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -435,6 +435,7 @@ class Minitest::Test
     Store.destroy_all
     Animal.destroy_all
     Speaker.destroy_all
+    Region.destroy_all
   end
 
   protected


### PR DESCRIPTION
Implements the interface described in #765, with tests and readme. All geoJSON shapes are supported, mostly because we just pass them through without amendment or validation. There is a very little sugar for envelopes to give some consistency with geo_point searches, but elasticsearch isn't consistent in this area so perhaps that's not needed.