### PR TITLE
Resolve lazy rescue TODO

### DIFF
--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -4,7 +4,7 @@ module Searchkick
 
     def perform(klass, id)
       model = klass.constantize
-      record = model.find(id) rescue nil # TODO fix lazy coding
+      record = model.find_by(id: id)
       index = model.searchkick_index
       if !record || !record.should_index?
         # hacky


### PR DESCRIPTION
`rescue`ing from `#find` on an `ActiveRecord` model is fine, but we can skip the slow `rescue` flow by using `#find_by` instead. Since we were `rescue`ing and returning `nil`, `#find_by` will provide the same behavior.

Notably, one possible regression here is that if `#find_by` fails for some other reason, such as no connection to the database, this will end up raising that exception instead of simply returning `nil` as the previous version does. Arguably this is better, though, as we wouldn't want to remove a record from the search index simply because we couldn't connect to the database at the right moment.