### PR TITLE
Allow body to be specified for aggs to enable advanced aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,13 @@ Date histogram
 Product.search "pear", aggs: {products_per_year: {date_histogram: {field: :created_at, interval: :year}}}
 ```
 
+Metrics aggregations and more! Specify a `body` to provide aggregation params manually.
+For example, to get an [average](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html) for a particular field:
+
+```
+Product.search "pear", aggs: {average_price: {body: {avg: {field: :price}}}}
+```
+
 #### Moving From Facets
 
 1. Replace `facets` with `aggs` in searches. **Note:** Stats facets are not supported at this time.

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -610,6 +610,8 @@ module Searchkick
               interval: interval
             }
           }
+        elsif agg_options[:body] # If body is specified, use it directly without any remapping
+          payload[:aggs][field] = agg_options[:body]
         else
           payload[:aggs][field] = {
             terms: {

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -116,6 +116,14 @@ class AggsTest < Minitest::Test
     assert_equal 4, products.aggs["products_per_year"]["buckets"].size
   end
 
+  def test_manual_agg_body
+    agg = Product.search("Product", aggs: {store_count: {body: {value_count: {field: :store_id}}}}).aggs["store_count"]
+    assert_equal 3, agg["value"]
+
+    agg = Product.search("Product", where: {in_stock: false}, aggs: {average_price: {body: {avg: {field: :price}}}}).aggs["average_price"]
+    assert_equal 15.0, agg["value"]
+  end
+
   protected
 
   def buckets_as_hash(agg)


### PR DESCRIPTION
I didn't see a way to do this right now. Currently it looks like you can only use a few types of aggregations or else it will simply remap to a default bucket terms aggregation. This PR allows for an aggregation body to be specified (got the idea since body is used for advanced searching). This lets us use all of elasticsearch's aggregations without having code for each one:

```
Product.search("*", aggs: {average_price: {body: {avg: {field: :price}}}})

Product.search("*", aggs: {price_stats: {body: {stats: {field: :price}}}})
```