### PR TITLE
Add removed options to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Breaking changes
 
 - Removed support for Elasticsearch 1 as it reaches [end of life](https://www.elastic.co/support/eol)
 - Removed facets, legacy options, and legacy methods
+- replace merge_mappings option with default_mappings
+- remove query and json search options (use body instead)
+- remove include option (use includes instead)
+- removed personalize option (use boost_where instead)
+- remove partial option (use operator instead)
 - Invalid options now throw an `ArgumentError`
 - Renamed `select_v2` to `select` (legacy `select` no longer available)
 - The `_all` field is disabled if `searchable` option is used (for performance)

--- a/README.md
+++ b/README.md
@@ -1727,6 +1727,11 @@ Important notes are listed below.
 
 - Removed support for Elasticsearch 1 as it reaches [end of life](https://www.elastic.co/support/eol)
 - Removed facets, legacy options, and legacy methods
+- replace merge_mappings option with default_mappings
+- remove query and json search options (use body instead)
+- remove include option (use includes instead)
+- removed personalize option (use boost_where instead)
+- remove partial option (use operator instead)
 - Invalid options now throw an `ArgumentError`
 - Renamed `select_v2` to `select` (legacy `select` no longer available)
 - The `_all` field is disabled if `searchable` option is used (for performance)


### PR DESCRIPTION
While adding I ran into the syntax change from `include` to `includes`. I added that option and some others that I noticed changed in #717 to the "breaking changes" section in the changelog and the readme to clarify for others that are working through the upgrade.

Can't wait to try out the goodies in 2.0...  especially queuing callback for batch updates!