### PR TITLE
Added support for multi_match query with cross_fields type

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -17,7 +17,8 @@ module Searchkick
         :boost_by, :boost_by_distance, :boost_where, :conversions, :debug, :emoji, :exclude, :execute, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
         :match, :misspellings, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :select, :similar, :smart_aggs, :suggest, :track, :type, :where]
+        :request_params, :routing, :select, :similar, :smart_aggs, :suggest, :track, :type, :where,
+        :cross_fields]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s
@@ -226,6 +227,47 @@ module Searchkick
               min_doc_freq: 1,
               min_term_freq: 1,
               analyzer: "searchkick_search2"
+            }
+          }
+        elsif options[:cross_fields]
+          queries = []
+
+          mmq = {}
+          fields.each do |field|
+            factor = boost_fields[field] || 1
+            analyzers=[]
+            if field == "_all" || field.end_with?(".analyzed")
+              f = field
+              analyzers=['searchkick_word_search', 'searchkick_search', 'searchkick_search2']
+            elsif field.end_with?(".exact")
+              f = field.split(".")[0..-2].join(".")
+              analyzers=['keyword']
+            else
+              f = field
+              analyzers << field =~ /\.word_(start|middle|end)\z/ ? "searchkick_word_search" : "searchkick_autocomplete_search"
+            end
+            analyzers.each do |a|
+              mmq[a] = [] unless mmq[a]
+              mmq[a] << "#{f}^#{factor*10}"
+            end
+          end
+
+          mmq.each do |a, f|
+            query = {
+              multi_match: {
+                query: term,
+                type: "cross_fields",
+                fields: f,
+                analyzer: a,
+                operator: operator
+              }
+            }
+
+            queries << query
+          end
+          payload = {
+            bool: {
+              should: queries
             }
           }
         elsif all

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -253,4 +253,30 @@ class MatchTest < Minitest::Test
     store_names ["Ice Cream Cake"]
     assert_search "🍨🍰", ["Ice Cream Cake"], emoji: true
   end
+
+	#Tests for: multi_match query with cross_fields type
+	def test_cross_fields_simple
+		store [
+			{name: "Gymboree Dinobot Boys' Tshirt", color: "white"},
+			{name: "Gymboree Dinomite Boys' Tshirt", color: "blue"},
+			{name: "Disney Pete's Dragon Little Boys Tshirt", color: "grey"},
+			{name: "Disney Mickey Mouse Boys' TShirt", color: "red"},
+			{name: "Disney Minnie Mouse Boys' TShirt", color: "white"},
+		]
+		assert_search "white tshirt", ["Gymboree Dinobot Boys' Tshirt", "Disney Minnie Mouse Boys' TShirt"], {fields: ['name', 'color'], cross_fields: true}
+
+		assert_search "blue tshirts", ["Gymboree Dinomite Boys' Tshirt"], {fields: ['name', 'color'], cross_fields: true}
+	end
+
+	def test_cross_fields_boost
+		store [
+			{name: "Gymboree Dinobot Boys' Tshirt", color: "white"},
+			{name: "Gymboree Dinomite Boys' Tshirt", color: "blue"},
+			{name: "Disney Pete's Dragon Little Boys Tshirt", color: "grey"},
+			{name: "Disney Baby Boys Grey Mickey Mouse Red White and COOL! TShirt", color: "grey"},
+			{name: "Disney Minnie Mouse Boys' TShirt", color: "white"},
+		]
+		assert_order "white tshirt", ["Disney Baby Boys Grey Mickey Mouse Red White and COOL! TShirt", "Gymboree Dinobot Boys' Tshirt", "Disney Minnie Mouse Boys' TShirt"], {fields: ['name^50', 'color'], cross_fields: true}
+	end
+
 end


### PR DESCRIPTION
Added support for multi_match query with cross_fields type.
example usage
`
Product.search "abc def ghi", fields: ['field1^20', 'field2^10'], cross_fields: true
`
