### PR TITLE
Support cardinality metric aggregator

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -643,6 +643,12 @@ module Searchkick
               interval: interval
             }
           }
+        elsif agg_options[:cardinality]
+          payload[:aggs][field] = {
+            cardinality: {
+              field: agg_options[:cardinality][:field] || field
+            }
+          }
         else
           payload[:aggs][field] = {
             terms: {

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -116,6 +116,20 @@ class AggsTest < Minitest::Test
     assert_equal 4, products.aggs["products_per_year"]["buckets"].size
   end
 
+  def test_aggs_cardinality
+    products =
+      Product.search("*", {
+        aggs: {
+          total_stores: {
+            cardinality: {
+              field: :store_id
+            }
+          }
+        }
+      })
+    assert_equal 3, products.aggs["total_stores"]["value"]
+  end
+
   protected
 
   def buckets_as_hash(agg)


### PR DESCRIPTION
Support cardinality metric aggregator - I suspect a next incremental step could be support for more metric aggregators by just maintaining a list of them (ie [:cardinality, :value_count...]), I think they are pretty much all the same in terms of query structure.