### PR TITLE
Match test mode when using parallel_spec

### DIFF
--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -148,7 +148,7 @@ module Searchkick
           }
         }
 
-        if Searchkick.env == "test"
+        if Searchkick.env =~ /test/
           settings[:number_of_shards] = 1
           settings[:number_of_replicas] = 0
         end


### PR DESCRIPTION
Hi, we're following these instructions to get parallel_spec + searchkick working: https://github.com/grosser/parallel_tests/wiki#with-searchkick----by-emaxi

This corrects behaviour across all running processes