### PR TITLE
Use an after create hook instead of manual reindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,18 +1769,25 @@ end
 
 ### Factory Girl
 
-Use an after `create` hook for each indexed model:
+Use a trait and an after `create` hook for each indexed model:
 
 ```ruby
 FactoryGirl.define do
   factory :product do
     # ...
-    
-    after(:create) do |product, evaluator|
-      Product.reindex
+
+    # Note: This should be the last trait in the list so `reindex` is called
+    # after all the other callbacks complete.
+    trait :reindex do
+      after(:create) do |product, _evaluator|
+        product.reindex(refresh: true)
+      end
     end
   end
 end
+
+# use it
+FactoryGirl.create(:product, :some_trait, :reindex, some_attribute: "foo")
 ```
 
 ### Parallel Tests

--- a/README.md
+++ b/README.md
@@ -1769,11 +1769,18 @@ end
 
 ### Factory Girl
 
-Manually reindex after an instance is created.
+Use an after `create` hook for each indexed model:
 
 ```ruby
-product = FactoryGirl.create(:product)
-product.reindex(refresh: true)
+FactoryGirl.define do
+  factory :product do
+    # ...
+    
+    after(:create) do |product, evaluator|
+      Product.reindex
+    end
+  end
+end
 ```
 
 ### Parallel Tests


### PR DESCRIPTION
I always use FactoryGirl's `after create` hook to reindex. Since typically I only create only a handful models needed for each test, this is very quick and I don't have to remember anything.