### PR TITLE
fix bulk index without IDs ankane/searchkick#907

### DIFF
--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -2,8 +2,8 @@ require_relative "test_helper"
 
 class ErrorsTest < Minitest::Test
   def test_bulk_import_raises_error
-    valid_dog = Product.new(name: "2016-01-02")
-    invalid_dog = Product.new(name: "Ol' One-Leg")
+    valid_dog = Product.create(name: "2016-01-02")
+    invalid_dog = Product.create(name: "Ol' One-Leg")
     index = Searchkick::Index.new "dogs", mappings: {
       dog: {
         properties: {


### PR DESCRIPTION
This will create products before trying to index in ES which prevent ES to complain that products do not have valid ID.