### PR TITLE
custom search analyzer

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -36,7 +36,7 @@ module Searchkick
   class ImportError < Error; end
 
   class << self
-    attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_suffix, :queue_name
+    attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_suffix, :queue_name, :searchkick_search_analyzer, :searchkick_search2_analyzer
     attr_writer :client, :env, :search_timeout
     attr_reader :aws_credentials
   end
@@ -46,6 +46,8 @@ module Searchkick
   self.models = []
   self.client_options = {}
   self.queue_name = :searchkick
+  self.searchkick_search_analyzer = 'searchkick_search'
+  self.searchkick_search2_analyzer = 'searchkick_search2'
 
   def self.client
     @client ||= begin

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -226,7 +226,7 @@ module Searchkick
               like_text: term,
               min_doc_freq: 1,
               min_term_freq: 1,
-              analyzer: "searchkick_search2"
+              analyzer: Searchkick.searchkick_search2_analyzer
             }
           }
           if fields != ["_all"]
@@ -299,10 +299,10 @@ module Searchkick
             if field == "_all" || field.end_with?(".analyzed")
               shared_options[:cutoff_frequency] = 0.001 unless operator == "and" || misspellings == false
               qs.concat [
-                shared_options.merge(analyzer: "searchkick_search"),
-                shared_options.merge(analyzer: "searchkick_search2")
+                shared_options.merge(analyzer: Searchkick.searchkick_search_analyzer),
+                shared_options.merge(analyzer: Searchkick.searchkick_search2_analyzer)
               ]
-              exclude_analyzer = "searchkick_search2"
+              exclude_analyzer = Searchkick.searchkick_search2_analyzer
             elsif field.end_with?(".exact")
               f = field.split(".")[0..-2].join(".")
               queries_to_add << {match: {f => shared_options.merge(analyzer: "keyword")}}


### PR DESCRIPTION
related issue: https://github.com/ankane/searchkick/issues/333

with this PR, we can do this:

```ruby
Searchkick.searchkick_search_analyzer = :ik_max_word
Searchkick.searchkick_search2_analyzer = :ik_smart
```

and perform query:

```text
curl http://localhost:9200/hub_product/_search?pretty -d '{"query":{"dis_max":{"queries":[{"match":{"_all":{"query":"滴滴打车","boost":10,"operator":"and","analyzer":"ik_max_word"}}},{"match":{"_all":{"query":"滴滴打车","boost":10,"operator":"and","analyzer":"ik_smart"}}},{"match":{"_all":{"query":"滴滴打车","boost":1,"operator":"and","analyzer":"ik_max_word","fuzziness":1,"prefix_length":0,"max_expansions":3,"fuzzy_transpositions":true}}},{"match":{"_all":{"query":"滴滴打车","boost":1,"operator":"and","analyzer":"ik_smart","fuzziness":1,"prefix_length":0,"max_expansions":3,"fuzzy_transpositions":true}}}]}},"size":1000,"from":0,"timeout":"101s","_source":false}'
```