### PR TITLE
Add support for conversions boost term

### DIFF
--- a/README.md
+++ b/README.md
@@ -1587,9 +1587,10 @@ end
 and during query time:
 
 ```ruby
-Product.search("banana") # boost by both fields (default)
+Product.search("banana") # boost by both fields (default) and term (banana) will be used for both matching and boosting.
 Product.search("banana", conversions: "total_conversions") # only boost by total_conversions
 Product.search("banana", conversions: false) # no conversion boosting
+Product.search("banana", conversions: "total_conversions", conversions_term: "organic banana") # Match banana but boost by organic banana
 ```
 
 Change timeout

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -16,7 +16,7 @@ module Searchkick
 
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :body, :body_options, :boost,
-        :boost_by, :boost_by_distance, :boost_where, :conversions, :debug, :emoji, :exclude, :execute, :explain,
+        :boost_by, :boost_by_distance, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :execute, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
         :match, :misspellings, :offset, :operator, :order, :padding, :page, :per_page, :profile,
         :request_params, :routing, :select, :similar, :smart_aggs, :suggest, :track, :type, :where]
@@ -381,7 +381,7 @@ module Searchkick
                       boost_mode: "replace",
                       query: {
                         match: {
-                          "#{conversions_field}.query" => term
+                          "#{conversions_field}.query" => options[:conversions_term] || term
                         }
                       }
                     }.merge(script_score)

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -28,6 +28,18 @@ class BoostTest < Minitest::Test
     assert_order "speaker", ["Speaker A", "Speaker B", "Speaker C"], {conversions: "conversions_b"}, Speaker
   end
 
+  def test_multiple_conversions_with_boost_term
+    store [
+      {name: "Speaker A", conversions_a: {"speaker" => 4, "speaker_1" => 1}},
+      {name: "Speaker B", conversions_a: {"speaker" => 3, "speaker_1" => 2}},
+      {name: "Speaker C", conversions_a: {"speaker" => 2, "speaker_1" => 3}},
+      {name: "Speaker D", conversions_a: {"speaker" => 1, "speaker_1" => 4}}
+    ], Speaker
+
+    assert_order "speaker", ["Speaker A", "Speaker B", "Speaker C", "Speaker D"], {conversions: "conversions_a"}, Speaker
+    assert_order "speaker", ["Speaker D", "Speaker C", "Speaker B", "Speaker A"], {conversions: "conversions_a", conversions_term: "speaker_1"}, Speaker
+  end
+
   def test_conversions_stemmed
     store [
       {name: "Tomato A", conversions: {"tomato" => 1, "tomatos" => 1, "Tomatoes" => 1}},


### PR DESCRIPTION
**Why?**

Currently, when boosting on conversions we use the term for boosting. This PR will add support to have separate conversion boost term.

One way to improve search results is if we can have separate terms for matching and boosting.

Example :
   *  organic banana:
      * Entity : banana
      * Attribute: organic

We need a way to use the existing conversions for boosting (using popularity for boosting) and be more flexible with matching. In our case match would be with "banana" and conversions boosting will be with "organic banana"

cc @ankane @meetrajesh 

