### PR TITLE
maintain boost oreder in where query active record

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -189,8 +189,7 @@ module Searchkick
 
       if records.respond_to?(:primary_key) && records.primary_key
         # ActiveRecord
-        records = records.where(records.primary_key => ids)
-        ids.collect {|id| records.detect {|x| x.id == id.to_i}}.compact
+        records.where(records.primary_key => ids).order("position(#{records.first.class.table_name}.id::text in '#{ids.join(',')}')") if records.first
       elsif records.respond_to?(:all) && records.all.respond_to?(:for_ids)
         # Mongoid 2
         records.all.for_ids(ids)

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -189,7 +189,7 @@ module Searchkick
 
       if records.respond_to?(:primary_key) && records.primary_key
         # ActiveRecord
-        records.where(records.primary_key => ids)
+        records.where(records.primary_key => ids).order("position(id::text in '#{ids.join(',')}')")
       elsif records.respond_to?(:all) && records.all.respond_to?(:for_ids)
         # Mongoid 2
         records.all.for_ids(ids)

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -189,7 +189,8 @@ module Searchkick
 
       if records.respond_to?(:primary_key) && records.primary_key
         # ActiveRecord
-        records.where(records.primary_key => ids).order("position(id::text in '#{ids.join(',')}')")
+        records = records.where(records.primary_key => ids)
+        ids.collect {|id| records.detect {|x| x.id == id.to_i}}.compact
       elsif records.respond_to?(:all) && records.all.respond_to?(:for_ids)
         # Mongoid 2
         records.all.for_ids(ids)


### PR DESCRIPTION
@ankane, In my project I was using searchkick version 1.3.1. As per the requirement we need to boost title more then description so I used the boost by title in query like - 

`FeedItem.search(query, fields: ["title^3", "description^1"]`

But I was not getting the right order after boosting so I debug the issue and found a small issue in gem that It does not maintain the Active Record Order after boosting.

I just fixed the issue on branch 'boost_active_record_ordering'. I created this branch from tag v1.3.1.