### PR TITLE
Fix non-numeric async reindex

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -433,8 +433,9 @@ module Searchkick
             bulk_reindex_job scope, batch_id, min_id: min_id, max_id: min_id + batch_size - 1
           end
         else
-          batch_id = 1
-          scope.in_batches(of: batch_size).each do |batch|
+          scope.in_batches(of: batch_size).each_with_index do |batch, i|
+            batch_id = i + 1
+
             bulk_reindex_job scope, batch_id, record_ids: batch.pluck(primary_key)
           end
         end

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -43,8 +43,12 @@ class ReindexTest < Minitest::Test
     skip if !defined?(ActiveJob)
 
     Sku.create(id: SecureRandom.hex, name: "Test")
-
     reindex = Sku.reindex(async: true)
+    assert_search "sku", [], conversions: false
+
+    index = Searchkick::Index.new(reindex[:index_name])
+    index.refresh
+    assert_equal 1, index.total_docs
   end
 
   def test_refresh_interval

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -39,6 +39,14 @@ class ReindexTest < Minitest::Test
     assert_search "product", ["Product A"]
   end
 
+  def test_async_non_integer_pk
+    skip if !defined?(ActiveJob)
+
+    Sku.create(id: SecureRandom.hex, name: "Test")
+
+    reindex = Sku.reindex(async: true)
+  end
+
   def test_refresh_interval
     reindex = Product.reindex(refresh_interval: "30s", async: true, import: false)
     index = Searchkick::Index.new(reindex[:index_name])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,6 +111,12 @@ if defined?(Mongoid)
 
   class Cat < Animal
   end
+
+  class Sku
+    include Mongoid::Document
+
+    field :name
+  end
 elsif defined?(NoBrainer)
   NoBrainer.configure do |config|
     config.app_name = :searchkick
@@ -170,6 +176,13 @@ elsif defined?(NoBrainer)
   end
 
   class Cat < Animal
+  end
+
+  class Sku
+    include NoBrainer::Document
+
+    field :id,   type: String
+    field :name, type: String
   end
 elsif defined?(Cequel)
   cequel =
@@ -250,6 +263,13 @@ elsif defined?(Cequel)
   end
 
   class Cat < Animal
+  end
+
+  class Sku
+    include Cequel::Record
+
+    key :id, :uuid
+    column :name, :text
   end
 
   [Product, Store, Region, Speaker, Animal].each(&:synchronize_schema)
@@ -487,7 +507,6 @@ end
 class Sku
   searchkick \
     text_start: [:name],
-    suggest: [:name],
     index_name: -> { "#{name.tableize}-#{Date.today.year}#{Searchkick.index_suffix}" },
     callbacks: defined?(ActiveJob) ? :async : true
 end
@@ -508,6 +527,7 @@ class Minitest::Test
     Store.destroy_all
     Animal.destroy_all
     Speaker.destroy_all
+    Sku.destroy_all
   end
 
   protected

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -505,10 +505,7 @@ class Animal
 end
 
 class Sku
-  searchkick \
-    text_start: [:name],
-    index_name: -> { "#{name.tableize}-#{Date.today.year}#{Searchkick.index_suffix}" },
-    callbacks: defined?(ActiveJob) ? :async : true
+  searchkick callbacks: defined?(ActiveJob) ? :async : true
 end
 
 Product.searchkick_index.delete if Product.searchkick_index.exists?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -339,6 +339,10 @@ else
     t.string :type
   end
 
+  ActiveRecord::Migration.create_table :skus, id: :uuid do |t|
+    t.string :name
+  end
+
   class Product < ActiveRecord::Base
     belongs_to :store
   end
@@ -360,6 +364,9 @@ else
   end
 
   class Cat < Animal
+  end
+
+  class Sku < ActiveRecord::Base
   end
 end
 
@@ -475,6 +482,14 @@ class Animal
     index_name: -> { "#{name.tableize}-#{Date.today.year}#{Searchkick.index_suffix}" },
     callbacks: defined?(ActiveJob) ? :async : true
     # wordnet: true
+end
+
+class Sku
+  searchkick \
+    text_start: [:name],
+    suggest: [:name],
+    index_name: -> { "#{name.tableize}-#{Date.today.year}#{Searchkick.index_suffix}" },
+    callbacks: defined?(ActiveJob) ? :async : true
 end
 
 Product.searchkick_index.delete if Product.searchkick_index.exists?


### PR DESCRIPTION
Calling `ModelScope.reindex(async: true)` fails when non-numerical primary keys are in play, such as UUID’s.

Unless the primary key has a database column type of integer, float, or
decimal, index in batches by plucking the primary key column and
sending it to the job as record_ids.