### PR TITLE
Remove eager loading when getting maximum and minimum ids in async scheduling

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -418,6 +418,8 @@ module Searchkick
 
     def full_reindex_async(scope)
       if scope.respond_to?(:primary_key)
+        # remove eager loading from scope
+        scope = scope.unscope(:includes) if scope.respond_to?(:unscope)
         # TODO expire Redis key
         primary_key = scope.primary_key
 


### PR DESCRIPTION
Maximum and minimum frequently fail when using complicated `includes` clauses that result in Rails doing joins (e.g. `has_and_belongs_to_many`) as the resulting SQL that ActiveRecord produces is invalid. As the eager loading is completely useless anyway when scheduling the tasks, it can just be discarded.