### PR TITLE
Make multi_search work with misspellings_below option

### DIFF
--- a/lib/searchkick/multi_search.rb
+++ b/lib/searchkick/multi_search.rb
@@ -1,0 +1,39 @@
+module Searchkick
+  class MultiSearch
+    attr_reader :queries
+
+    def initialize(queries)
+      @queries = queries
+    end
+
+    def perform
+      if queries.any?
+        perform_search(queries)
+      end
+    end
+
+    private
+
+    def perform_search(queries, retry_below_misspellings_threshold: true)
+      responses = client.msearch(body: queries.flat_map { |q| [q.params.except(:body), q.body] })["responses"]
+
+      queries_below_misspellings_threshold = []
+      queries.each_with_index do |query, i|
+        if query.below_misspellings_threshold?(responses[i])
+          query.prepare
+          queries_below_misspellings_threshold << query
+        else
+          query.handle_response(responses[i])
+        end
+      end
+
+      if retry_below_misspellings_threshold && queries_below_misspellings_threshold.any?
+        perform_search(queries_below_misspellings_threshold, retry_below_misspellings_threshold: false)
+      end
+    end
+
+    def client
+      Searchkick.client
+    end
+  end
+end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -4,7 +4,7 @@ module Searchkick
 
     @@metric_aggs = [:avg, :cardinality, :max, :min, :sum]
 
-    attr_reader :klass, :term, :options
+    attr_reader :klass, :term, :options, :misspellings_below
     attr_accessor :body
 
     def_delegators :execute, :map, :each, :any?, :empty?, :size, :length, :slice, :[], :to_ary,

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -19,4 +19,12 @@ class MultiSearchTest < Minitest::Test
     assert !products.error
     assert stores.error
   end
+
+  def test_misspellings_below_unmet
+    store_names ["Product A"]
+    store_names ["Store A"], Store
+    stores = Store.search("Stre A", misspellings: { below: 2 }, execute: false)
+    Searchkick.multi_search([stores])
+    assert_equal ["Store A"], stores.map(&:name)
+  end
 end


### PR DESCRIPTION
Fixes #916 

## The Problem

When trying to combine `misspellings_below` option with `multi_search`, Searchkick does not perform the second search when the number of results is below the `misspellings_below` threshold.

## This Solution

This PR adds a test for this case and a change to `multi_search` which re-executes queries that are below their misspellings threshold.

The code in this PR is not perfect. We clearly don't want to be using a private `send` and there's a chance we don't want to expose `misspellings_below` as a publicly readable attribute. However, this PR demonstrates a solution to the problem in hopes of bringing us to the right solution.

This is my first time looking into the Searchkick code. If you feel I am on the right track, please leave feedback and I will be happy to refine this into production-ready code. Or feel free to update it yourself.

Thanks!