### PR TITLE
Adds an optional 'missing' param to boost_by

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -872,7 +872,7 @@ module Searchkick
           }
         }
 
-        if value[:missing].present?
+        if value[:missing].present? && !below50?
           script_score[:field_value_factor].merge!({missing: value[:missing].to_f})
         end
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -872,6 +872,10 @@ module Searchkick
           }
         }
 
+        if value[:missing].present?
+          script_score[:field_value_factor].merge!({missing: value[:missing].to_f})
+        end
+
         {
           filter: {
             exists: {

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -872,8 +872,12 @@ module Searchkick
           }
         }
 
-        if value[:missing].present? && !below50?
-          script_score[:field_value_factor].merge!({missing: value[:missing].to_f})
+        if value[:missing].present?
+          if below50?
+            raise ArgumentError, "Option 'missing' for boost_by supported in Elasticsearch 5 or greater"
+          else
+            script_score[:field_value_factor].merge!({missing: value[:missing].to_f})
+          end
         end
 
         {

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -117,8 +117,6 @@ class BoostTest < Minitest::Test
   end
 
   def test_boost_by_missing_field
-    skip if elasticsearch_below50?
-
     store [
       {name: "Tomato A"},
       {name: "Tomato B", orders_count: 10},
@@ -129,7 +127,13 @@ class BoostTest < Minitest::Test
       assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5}}
     end
 
-    assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5, missing: 1}}
+    if elasticsearch_below50?
+      assert_raises(ArgumentError) do
+        assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5, missing: 1}}
+      end
+    else
+      assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5, missing: 1}}
+    end
   end
 
   def test_boost_by_boost_mode_multiply

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -114,9 +114,21 @@ class BoostTest < Minitest::Test
     ]
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: [:orders_count]
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 10}}
+  end
+
+  def test_boost_by_missing_field
+    skip if elasticsearch_below50?
+
+    store [
+      {name: "Tomato A"},
+      {name: "Tomato B", orders_count: 10},
+      {name: "Tomato C", orders_count: 100}
+    ]
+
     assert_raises(Searchkick::InvalidQueryError) do
       assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5}}
     end
+
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5, missing: 1}}
   end
 

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -114,6 +114,10 @@ class BoostTest < Minitest::Test
     ]
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: [:orders_count]
     assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 10}}
+    assert_raises(Searchkick::InvalidQueryError) do
+      assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5}}
+    end
+    assert_order "tomato", ["Tomato C", "Tomato B", "Tomato A"], boost_by: {orders_count: {factor: 5}, orders_value: {factor: 5, missing: 1}}
   end
 
   def test_boost_by_boost_mode_multiply


### PR DESCRIPTION
Simply adds `missing` key and value to `field_value_factor`, which helps avoid `Searchkick::InvalidQueryError` on unmapped fields. 

Let me know what you think!