### PR TITLE
Prevents ES from sending gzip'd responses.

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -53,7 +53,7 @@ module Searchkick
 
       Elasticsearch::Client.new({
         url: ENV["ELASTICSEARCH_URL"],
-        transport_options: {request: {timeout: timeout}, headers: {content_type: "application/json"}}
+        transport_options: {request: {timeout: timeout}, headers: {content_type: "application/json", "Accept-Encoding": ""}}
       }.deep_merge(client_options)) do |f|
         f.use Searchkick::Middleware
         f.request :aws_signers_v4, {


### PR DESCRIPTION
This is a simple fix for AWS ES new behavior to send gzipped responses when Accept-Encoding is not set.  

An alternative approach would to enable FaradayMiddleware::Gzip.  This would automatically set Accept-Encoding to “gzip,deflate”.

See https://github.com/elastic/elasticsearch-ruby/issues/457 for slightly more info.