### PR TITLE
Added support for custom field_value_factor modifier.

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -873,13 +873,11 @@ module Searchkick
 
     def boost_filters(boost_by, options = {})
       boost_by.map do |field, value|
-        log = value.key?(:log) ? value[:log] : options[:log]
-        value[:factor] ||= 1
         script_score = {
           field_value_factor: {
             field: field,
-            factor: value[:factor].to_f,
-            modifier: log ? "ln2p" : nil
+            modifier: (value[:modifier] or ( (value[:log] or options[:log]) ? 'ln2p' : nil ) or 'none'),
+            factor: (value[:factor] ? value[:factor].to_f : 1),
           }
         }
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -873,10 +873,11 @@ module Searchkick
 
     def boost_filters(boost_by, options = {})
       boost_by.map do |field, value|
+        log = value.key?(:log) ? value[:log] : options[:log]
         script_score = {
           field_value_factor: {
             field: field,
-            modifier: (value[:modifier] or ( (value[:log] or options[:log]) ? 'ln2p' : nil ) or 'none'),
+            modifier: (value[:modifier] or (log ? 'ln2p' : nil ) or nil ),
             factor: (value[:factor] ? value[:factor].to_f : 1),
           }
         }


### PR DESCRIPTION
The implementation maintains backwards compatability with the `log` parameter,
though it should be depricated.

This fixes #498.