### PR TITLE
Set ignore_above option based on ES version

### DIFF
--- a/lib/searchkick/server_version.rb
+++ b/lib/searchkick/server_version.rb
@@ -1,0 +1,7 @@
+module Searchkick
+  class ServerVersion
+    V_5_0_0_ALPHA  = '5.0.0-alpha1'
+    V_6_0_0_ALPHA1 = '6.0.0-alpha1'
+    V_2_2_0        = '2.2.0'
+  end
+end

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -146,7 +146,7 @@ class IndexTest < Minitest::Test
     large_value = 1000.times.map { "hello" }.join(" ")
     store [{name: "Product A", text: large_value}], Region
     assert_search "product", ["Product A"], {}, Region
-    assert_search "hello", ["Product A"], {fields: [:name, :text]}, Region
+    assert_search "hello", [], {fields: [:name, :text]}, Region
 
     # needs fields for ES 6
     if elasticsearch_below60?
@@ -154,13 +154,21 @@ class IndexTest < Minitest::Test
     end
   end
 
-  def test_very_large_value
+  def test_very_large_value_server_above22
     skip if nobrainer? || elasticsearch_below22?
     large_value = 10000.times.map { "hello" }.join(" ")
     store [{name: "Product A", text: large_value}], Region
     assert_search "product", ["Product A"], {}, Region
-    assert_search "hello", ["Product A"], {fields: [:name, :text]}, Region
+    assert_search "hello", [], {fields: [:name, :text]}, Region
     # values that exceed ignore_above are not included in _all field :(
     # assert_search "hello", ["Product A"], {}, Region
+  end
+
+  def test_very_large_value_server_below22
+    skip if nobrainer? || !elasticsearch_below22?
+    large_value = 10000.times.map { "hello" }.join(" ")
+    store [{name: "Product A", text: large_value}], Region
+    assert_search "product", ["Product A"], {}, Region
+    assert_search "hello", ['Product A'], {fields: [:name, :text]}, Region
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require "minitest/pride"
 require "logger"
 require "active_support/core_ext" if defined?(NoBrainer)
 require "active_support/notifications"
+require "searchkick/server_version"
 
 Searchkick.index_suffix = ENV["TEST_ENV_NUMBER"]
 
@@ -39,15 +40,15 @@ end
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["NOTIFICATIONS"]
 
 def elasticsearch_below50?
-  Searchkick.server_below?("5.0.0-alpha1")
+  Searchkick.server_below?(Searchkick::ServerVersion::V_5_0_0_ALPHA)
 end
 
 def elasticsearch_below60?
-  Searchkick.server_below?("6.0.0-alpha1")
+  Searchkick.server_below?(Searchkick::ServerVersion::V_6_0_0_ALPHA1)
 end
 
 def elasticsearch_below22?
-  Searchkick.server_below?("2.2.0")
+  Searchkick.server_below?(Searchkick::ServerVersion::V_2_2_0)
 end
 
 def nobrainer?
@@ -471,6 +472,14 @@ end
 class Region
   searchkick \
     default_fields: elasticsearch_below60? ? nil : [:name],
+    merge_mappings: true,
+    mappings: {
+      region: {
+        properties: {
+          text: elasticsearch_below50? ? {type: "string", analyzer: "keyword"} : { type: 'text' }
+        }
+      }
+    },
     geo_shape: {
       territory: {tree: "quadtree", precision: "10km"}
     }


### PR DESCRIPTION
- Set **ignore_above** option only for Elasticsearch versions above 2.2.0 and when it's not a field of **text** type.
- It seems that this option is not valid for **text** field type on Elasticsearch version greater than 2.2.0 according to the links below:
https://stackoverflow.com/questions/41068670/elasticsearch-5-0-2-ignore-above-gives-unsupported-parameter-error
https://www.elastic.co/guide/en/elasticsearch/reference/master/ignore-above.html

Thoughts? 