### PR TITLE
Separate emoji parse method

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -24,9 +24,7 @@ module Searchkick
 
       term = term.to_s
 
-      if options[:emoji]
-        term = EmojiParser.parse_unicode(term) { |e| " #{e.name} " }.strip
-      end
+      term = parse_emoji(term) if options[:emoji]
 
       @klass = klass
       @term = term
@@ -928,6 +926,10 @@ module Searchkick
 
     def below60?
       Searchkick.server_below?("6.0.0-alpha1")
+    end
+    
+    def parse_emoji(term)
+      EmojiParser.parse_unicode(term) { |e| " #{e.name} " }.strip
     end
   end
 end


### PR DESCRIPTION
Separating emoji parse method allows developer to overwrite it.

Scenario:
If developer will store in ES parsed emoji in other way e.g. `[[crown]]` or `:crown:` instead `crown`, then let him overwrite this method, to use new format.