### PR TITLE
Handle sparse tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1667,6 +1667,15 @@ class Product < ActiveRecord::Base
 end
 ```
 
+Handle sparse tables
+
+```ruby
+class Product < ActiveRecord::Base
+  # Some tables have large id gaps which makes bulk reindexing inefficient
+  searchkick sparse_table: true
+end
+```
+
 Create index without importing
 
 ```ruby

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -455,7 +455,7 @@ module Searchkick
 
         if starting_id.nil?
           # no records, do nothing
-        elsif starting_id.is_a?(Numeric)
+        elsif !@options[:sparse_table] && starting_id.is_a?(Numeric)
           max_id = scope.maximum(primary_key)
           batches_count = ((max_id - starting_id + 1) / batch_size.to_f).ceil
 

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -4,7 +4,7 @@ module Searchkick
       unknown_keywords = options.keys - [:_all, :batch_size, :callbacks, :conversions, :default_fields,
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :language,
         :locations, :mappings, :match, :merge_mappings, :routing, :searchable, :settings, :similarity,
-        :special_characters, :stem_conversions, :suggest, :synonyms, :text_end,
+        :sparse_table, :special_characters, :stem_conversions, :suggest, :synonyms, :text_end,
         :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 


### PR DESCRIPTION
Some tables have large swaths of missing IDs so the default bulk reindexing strategy is extremely inefficient. In these cases falling back to find_in_batches, as if we didn't have numeric IDs in the first place is an appropriate compromise.

I wasn't able to find a test that covered this branch of Numeric batch handling so I didn't write a test 😱. If someone wants to point me in the right direction I'd be happy to mend my mistake.