### PR TITLE
Fix a race condition during reindex

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -226,11 +226,25 @@ module Searchkick
         raise Searchkick::Error, "No index to resume" unless index_name
         index = Searchkick::Index.new(index_name)
       else
-        clean_indices unless retain
-
         index_options = scope.searchkick_index_options
         index_options.deep_merge!(settings: {index: {refresh_interval: refresh_interval}}) if refresh_interval
-        index = create_index(index_options: index_options)
+
+        failed, timeout, next_timeout = 0, 0, 1
+        begin
+          clean_indices unless retain
+          index = create_index(index_options: index_options)
+        rescue Elasticsearch::Transport::Transport::Errors::BadRequest => e
+          failed = failed.succ
+          code, json = *e.message.split(' ', 2)
+          if json =~ /index_already_exists_exception/ && failed <= 10
+            # Use Fibonacci curve for timeouts
+            timeout, next_timeout = next_timeout, timeout + next_timeout
+            #puts "  #{color(name, ActiveSupport::LogSubscriber.YELLOW, true)}  failed #{failed} sleeping #{timeout}s #{e.message}"
+            sleep timeout
+            retry
+          end
+          raise e
+        end
       end
 
       # check if alias exists


### PR DESCRIPTION
As outlined in https://github.com/ankane/searchkick/issues/843
reindexing may sometimes fail with 'index_already_exists_exception'.

This primitive patch fixes it by retrying the index creation up to 10
times following a fibonacci timeout curve, that is on failure it waits
in seconds: 1, 1, 2, 3, 5, 8, 13, 21, 34, 55 before giving up.
Reindexing is a slow process anyways, so we can wait around 3 minutes
(including time needed for index deletion) before it finally fails.

For 1.5.1, please pull from kakra hotfix-1.5.1/fix-exception-on-reindex.

Signed-off-by: Kai Krakow <kai@kaishome.de>