### PR TITLE
Use Searchkick.queue_name for bulk indexing jobs

### DIFF
--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -1,6 +1,6 @@
 module Searchkick
   class BulkReindexJob < ActiveJob::Base
-    queue_as :searchkick
+    queue_as { Searchkick.queue_name }
 
     def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)
       klass = class_name.constantize

--- a/lib/searchkick/process_batch_job.rb
+++ b/lib/searchkick/process_batch_job.rb
@@ -1,6 +1,6 @@
 module Searchkick
   class ProcessBatchJob < ActiveJob::Base
-    queue_as :searchkick
+    queue_as { Searchkick.queue_name }
 
     def perform(class_name:, record_ids:)
       klass = class_name.constantize

--- a/lib/searchkick/process_queue_job.rb
+++ b/lib/searchkick/process_queue_job.rb
@@ -1,6 +1,6 @@
 module Searchkick
   class ProcessQueueJob < ActiveJob::Base
-    queue_as :searchkick
+    queue_as { Searchkick.queue_name }
 
     def perform(class_name:)
       model = class_name.constantize


### PR DESCRIPTION
ReindexV2Job uses Searchkick.queue_name for its ActiveJob queue, but the bulk indexing jobs are hardcoded to :searchkick (the default). This PR uses Searchkick.queue_name for the bulk jobs as well for consistency.