### PR TITLE
Add unscoped_reindex option that is used during async reindexing.

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -5,7 +5,7 @@ module Searchkick
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :language,
         :locations, :mappings, :match, :merge_mappings, :routing, :searchable, :settings, :similarity,
         :special_characters, :stem_conversions, :suggest, :synonyms, :text_end,
-        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start]
+        :text_middle, :text_start, :unscoped_reindex, :word, :wordnet, :word_end, :word_middle, :word_start]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       raise "Only call searchkick once per model" if respond_to?(:searchkick_index)

--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -13,7 +13,11 @@ module Searchkick
       model = klass.constantize
       record =
         begin
-          model.find(id)
+          if model.searchkick_options[:unscoped_reindex]
+            model.unscoped.find(id)
+          else
+            model.find(id)
+          end
         rescue => e
           # check by name rather than rescue directly so we don't need
           # to determine which classes are defined


### PR DESCRIPTION
This adds a new option to the searchkick model `unscoped_reindex` that is used by the ReindexV2Job to unscope the database query.

I wasn't sure the best way to test this?  Do I need to create a Model and give it a default_scope?  Is there some way to do this outside the Model with meta magic?

Issue here: https://github.com/ankane/searchkick/issues/893