### PR TITLE
Update README `keyword` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1415,7 +1415,7 @@ class Product < ApplicationRecord
   searchkick mappings: {
     product: {
       properties: {
-        name: {type: "string", analyzer: "keyword"}
+        name: {type: "keyword"}
       }
     }
   }


### PR DESCRIPTION
to the current ES version according to https://github.com/ankane/searchkick/blob/61ede188042c843c1dfd15fc724379ce69353887/test/test_helper.rb#L457

Otherwise, it's confusing.