### PR TITLE
Add references and model_references options to Query and Results

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -18,8 +18,8 @@ module Searchkick
       unknown_keywords = options.keys - [:aggs, :body, :body_options, :boost,
         :boost_by, :boost_by_distance, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :execute, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
-        :match, :misspellings, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :select, :similar, :smart_aggs, :suggest, :track, :type, :where]
+        :match, :misspellings, :model_includes, :model_references, :offset, :operator, :order, :padding, :page, :per_page,
+        :profile, :references, :request_params, :routing, :select, :similar, :smart_aggs, :suggest, :track, :type, :where]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s
@@ -109,6 +109,8 @@ module Searchkick
         load: @load,
         includes: options[:includes],
         model_includes: options[:model_includes],
+        references: options[:references],
+        model_references: options[:model_references],
         json: !@json.nil?,
         match_suffix: @match_suffix,
         highlighted_fields: @highlighted_fields || [],

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -196,6 +196,12 @@ class SqlTest < Minitest::Test
     assert Product.search("product", includes: [:store]).first.association(:store).loaded?
   end
 
+  def test_references
+    skip unless defined?(ActiveRecord)
+    store_names ["Product A"]
+    assert Product.search("product", includes: [:store], references: [:store]).first.association(:store).loaded?
+  end
+
   def test_model_includes
     skip unless defined?(ActiveRecord)
 
@@ -204,6 +210,25 @@ class SqlTest < Minitest::Test
 
     associations = {Product => [:store], Store => [:products]}
     result = Searchkick.search("*", index_name: [Product, Store], model_includes: associations)
+
+    assert_equal 2, result.length
+
+    result.group_by(&:class).each_pair do |klass, records|
+      assert records.first.association(associations[klass].first).loaded?
+    end
+  end
+
+  def test_model_references
+    skip unless defined?(ActiveRecord)
+
+    store_names ["Product A"]
+    store_names ["Store A"], Store
+
+    associations = {Product => [:store], Store => [:products]}
+    result = Searchkick.search("*",
+                               index_name: [Product, Store],
+                               model_includes: associations,
+                               model_references: associations)
 
     assert_equal 2, result.length
 


### PR DESCRIPTION
We can currently specify `includes` and `model_includes` options when generating a Query, which end up as combined `ActiveRecord::Relation#includes` arguments when generating a results query. 

However, if the query references an included association, an `ActiveRecord::StatementInvalid` error will be generated unless `ActiveRecord::Relation#references` is used to tell ActiveRecord to use a JOIN. 

This PR whitelists `references` and `model_references` keywords in the `Query` class and passes them when constructing an instance of `Results`. The `Results` class then conditionally calls `ActiveRecord::Relation#references` on the query relation. 