### PR TITLE
Added an option to return all highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,22 @@ bands.each do |band|
 end
 ```
 
+**Note:** If you have multiple highlights per field (whether you have an array field or multiple highlighted fragments) searchkick will return only the first one by default.
+
+To return all highlights use `fetch_all` option:
+
+```ruby
+bands = Band.search "cinema", fields: [:name], highlight: {fetch_all: true}
+```
+
+Now highlights will be returned as an array:
+
+```ruby
+bands.each do |band|
+  band.search_highlights[:name] # ["Two Door <em>Cinema</em> Club", "And Much More Doors <em>Cinema</em>"]
+end
+```
+
 To change the tag, use:
 
 ```ruby

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -112,6 +112,7 @@ module Searchkick
         json: !@json.nil?,
         match_suffix: @match_suffix,
         highlighted_fields: @highlighted_fields || [],
+        fetch_all_highlights: options[:highlight].is_a?(Hash) && !!options[:highlight][:fetch_all],
         misspellings: @misspellings,
         term: term
       }

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -41,7 +41,7 @@ module Searchkick
               end
 
               if hit["highlight"] && !result.respond_to?(:search_highlights)
-                highlights = Hash[hit["highlight"].map { |k, v| [(options[:json] ? k : k.sub(/\.#{@options[:match_suffix]}\z/, "")).to_sym, v.first] }]
+                highlights = Hash[hit["highlight"].map { |k, v| [(options[:json] ? k : k.sub(/\.#{@options[:match_suffix]}\z/, "")).to_sym, fetch_higlight(v)] }]
                 result.define_singleton_method(:search_highlights) do
                   highlights
                 end
@@ -61,7 +61,7 @@ module Searchkick
               end
 
             if hit["highlight"]
-              highlight = Hash[hit["highlight"].map { |k, v| [base_field(k), v.first] }]
+              highlight = Hash[hit["highlight"].map { |k, v| [base_field(k), fetch_higlight(v)] }]
               options[:highlighted_fields].map { |k| base_field(k) }.each do |k|
                 result["highlighted_#{k}"] ||= (highlight[k] || result[k])
               end
@@ -92,10 +92,14 @@ module Searchkick
       each_with_hit.map do |model, hit|
         details = {}
         if hit["highlight"]
-          details[:highlight] = Hash[hit["highlight"].map { |k, v| [(options[:json] ? k : k.sub(/\.#{@options[:match_suffix]}\z/, "")).to_sym, v.first] }]
+          details[:highlight] = Hash[hit["highlight"].map { |k, v| [(options[:json] ? k : k.sub(/\.#{@options[:match_suffix]}\z/, "")).to_sym, fetch_higlight(v)] }]
         end
         [model, details]
       end
+    end
+
+    def fetch_higlight(highlights)
+      options[:fetch_all_highlights] ? highlights : highlights.first
     end
 
     def aggregations

--- a/test/highlight_test.rb
+++ b/test/highlight_test.rb
@@ -51,6 +51,18 @@ class HighlightTest < Minitest::Test
     assert_equal "Two Door <em>Cinema</em> Club", Product.search("ine", fields: [:name], match: :word_middle, highlight: true).first.search_highlights[:name]
   end
 
+  def test_fetch_all
+    store [{name: "Two Door Cinema Club Some Other Words And Much More Doors Cinema Club" }]
+    highlights = Product.search("cinema", fields: [:name], highlight: { fetch_all: true, fragment_size: 20 } ).first.search_highlights
+    assert_equal ["Two Door <em>Cinema</em> Club", "And Much More Doors <em>Cinema</em>"], highlights[:name]
+  end
+
+  def test_fetch_one
+    store [{name: "Two Door Cinema Club Some Other Words And Much More Doors Cinema Club" }]
+    highlights = Product.search("cinema", fields: [:name], highlight: { fragment_size: 20 } ).first.search_highlights
+    assert_equal "Two Door <em>Cinema</em> Club", highlights[:name]
+  end
+
   def test_body
     skip if ENV["MATCH"] == "word_start"
     store_names ["Two Door Cinema Club"]

--- a/test/highlight_test.rb
+++ b/test/highlight_test.rb
@@ -53,14 +53,20 @@ class HighlightTest < Minitest::Test
 
   def test_fetch_all
     store [{name: "Two Door Cinema Club Some Other Words And Much More Doors Cinema Club" }]
-    highlights = Product.search("cinema", fields: [:name], highlight: { fetch_all: true, fragment_size: 20 } ).first.search_highlights
-    assert_equal ["Two Door <em>Cinema</em> Club", "And Much More Doors <em>Cinema</em>"], highlights[:name]
+    highlights = Product.search("cinema", fields: [:name], highlight: { fetch_all: true, fragment_size: 20 } ).first.search_highlights[:name]
+    assert highlights.is_a?(Array)
+    assert_equal highlights.count, 2
+    refute_equal highlights.first, highlights.last
+    highlights.each do |highlight|
+      assert highlight.include?("<em>Cinema</em>")
+    end
   end
 
   def test_fetch_one
     store [{name: "Two Door Cinema Club Some Other Words And Much More Doors Cinema Club" }]
-    highlights = Product.search("cinema", fields: [:name], highlight: { fragment_size: 20 } ).first.search_highlights
-    assert_equal "Two Door <em>Cinema</em> Club", highlights[:name]
+    highlights = Product.search("cinema", fields: [:name], highlight: { fragment_size: 20 } ).first.search_highlights[:name]
+    assert highlights.is_a?(String)
+    assert highlights.include?("<em>Cinema</em>")
   end
 
   def test_body


### PR DESCRIPTION
Let's give developers option to get all highlights instead of only first one. The default behavior remains, so existing user's code won't be broken by unexpected array instead of string returns.
Tests written, documentation extended.