### PR TITLE
Closes #1057 updates readme to clarify use of default_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ products.each do |product|
 end
 ```
 
+Or
+
+```ruby
+class Product < ApplicationRecord
+  searchkick default_fields: [:name]
+
+  products = Product.search("apples")
+  products.each do |product|
+    puts product.name
+  end
+end
+```
+
 Searchkick supports the complete [Elasticsearch Search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html). As your search becomes more advanced, we recommend you use the [Elasticsearch DSL](#advanced) for maximum flexibility.
 
 ## Querying


### PR DESCRIPTION
Clarifies the use of default_fields on a model instead of explicitly setting fields in the query. This helps with the adoption of ES6 as it will no longer default fields to _all.

Closes #1057 