### PR TITLE
automatically capitalize ENV["CLASS"] in rake task for better UX

### DIFF
--- a/lib/searchkick/tasks.rb
+++ b/lib/searchkick/tasks.rb
@@ -2,7 +2,7 @@ namespace :searchkick do
   desc "reindex model"
   task reindex: :environment do
     if ENV["CLASS"]
-      klass = ENV["CLASS"].constantize rescue nil
+      klass = ENV["CLASS"].capitalize.constantize rescue nil
       if klass
         klass.reindex
       else


### PR DESCRIPTION
Hi folks 👋

Thanks for your work on Searchkick. As this is a very small change, I haven't opened an issue. This PR is just a suggestion, so feel free to close if it you're not keen on it.

While pairing with a co-worker, his natural instinct when running the `reindex` rake task was to pass the model name as lowercase (`class=product` rather than `class=Product`). This was rejected with an error message that explained how to use the CLI.

I thought it might be nicer to tolerate both uppercase and lowercase model names, as long as they are spelt correctly 😸. This is consistent with Rails's rake tasks, and removes a bit of friction for the developer.