### PR TITLE
Add JSON to the development dependencies

### DIFF
--- a/searchkick.gemspec
+++ b/searchkick.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hashie"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "json"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
WIthout the JSON dependencies it will be not possible to run the tests
locally.
The dependency was added only to the development, since the running
environment will be under a Rails application, so a JSON implementation
is already provided.

Fixes #1096