### PR TITLE
Fix infinite recursion on multi search

### DIFF
--- a/lib/searchkick/multi_search.rb
+++ b/lib/searchkick/multi_search.rb
@@ -14,12 +14,12 @@ module Searchkick
 
     private
 
-    def perform_search(queries)
-      responses = client.msearch(body: queries.flat_map { |q| [q.params.except(:body), q.body] })["responses"]
+    def perform_search(search_queries, perform_retry: true)
+      responses = client.msearch(body: search_queries.flat_map { |q| [q.params.except(:body), q.body] })["responses"]
 
       retry_queries = []
-      queries.each_with_index do |query, i|
-        if query.retry_misspellings?(responses[i])
+      search_queries.each_with_index do |query, i|
+        if perform_retry && query.retry_misspellings?(responses[i])
           query.send(:prepare) # okay, since we don't want to expose this method outside Searchkick
           retry_queries << query
         else
@@ -28,10 +28,10 @@ module Searchkick
       end
 
       if retry_queries.any?
-        perform_search(retry_queries)
+        perform_search(retry_queries, perform_retry: false)
       end
 
-      queries
+      search_queries
     end
 
     def client

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -22,7 +22,7 @@ class MultiSearchTest < Minitest::Test
 
   def test_misspellings_below_unmet
     store_names ["abc", "abd", "aee"]
-    products = Product.search("abc", misspellings: {below: 2}, execute: false)
+    products = Product.search("abc", misspellings: {below: 5}, execute: false)
     Searchkick.multi_search([products])
     assert_equal ["abc", "abd"], products.map(&:name)
   end


### PR DESCRIPTION
When we retry a multi search, we should not perform subsequent retries,
otherwise we'll end in an inifite recursion if we don't have enough
matches.

In this commit, a new flag is added to mark the execution of a retry.
Also since we have a local variable and a method with the same name
`queries`, a rename was applied to the method argument to improve the
readability.