### PR TITLE
Add the frozen string literal

### DIFF
--- a/benchmark/index.rb
+++ b/benchmark/index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/setup"
 Bundler.require(:default)
 require "active_record"

--- a/benchmark/search.rb
+++ b/benchmark/search.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/setup"
 Bundler.require(:default)
 require "active_record"

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_model"
 require "active_support/core_ext/hash/deep_merge"
 require "elasticsearch"

--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class BulkIndexer
     attr_reader :index

--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class BulkReindexJob < ActiveJob::Base
     queue_as { Searchkick.queue_name }

--- a/lib/searchkick/hash_wrapper.rb
+++ b/lib/searchkick/hash_wrapper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   # Subclass of `Hashie::Mash` to wrap Hash-like structures
   # (responses from Elasticsearch)

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "searchkick/index_options"
 
 module Searchkick

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   module IndexOptions
     def index_options

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class Indexer
     attr_reader :queued_items

--- a/lib/searchkick/logging.rb
+++ b/lib/searchkick/logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # based on https://gist.github.com/mnutt/566725
 require "active_support/core_ext/module/attr_internal"
 

--- a/lib/searchkick/middleware.rb
+++ b/lib/searchkick/middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "faraday/middleware"
 
 module Searchkick

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   module Model
     def searchkick(**options)

--- a/lib/searchkick/multi_search.rb
+++ b/lib/searchkick/multi_search.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class MultiSearch
     attr_reader :queries

--- a/lib/searchkick/process_batch_job.rb
+++ b/lib/searchkick/process_batch_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class ProcessBatchJob < ActiveJob::Base
     queue_as { Searchkick.queue_name }

--- a/lib/searchkick/process_queue_job.rb
+++ b/lib/searchkick/process_queue_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class ProcessQueueJob < ActiveJob::Base
     queue_as { Searchkick.queue_name }

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class Query
     extend Forwardable

--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class RecordData
     EXCLUDED_ATTRIBUTES = ["id", :id]

--- a/lib/searchkick/record_indexer.rb
+++ b/lib/searchkick/record_indexer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class RecordIndexer
     attr_reader :record, :index

--- a/lib/searchkick/reindex_queue.rb
+++ b/lib/searchkick/reindex_queue.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class ReindexQueue
     attr_reader :name

--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   class ReindexV2Job < ActiveJob::Base
     RECORD_NOT_FOUND_CLASSES = [

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "forwardable"
 
 module Searchkick

--- a/lib/searchkick/tasks.rb
+++ b/lib/searchkick/tasks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :searchkick do
   desc "reindex model"
   task reindex: :environment do

--- a/lib/searchkick/version.rb
+++ b/lib/searchkick/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Searchkick
   VERSION = "3.0.1"
 end

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class AggsTest < Minitest::Test

--- a/test/autocomplete_test.rb
+++ b/test/autocomplete_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class AutocompleteTest < Minitest::Test

--- a/test/boost_test.rb
+++ b/test/boost_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class BoostTest < Minitest::Test

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class CallbacksTest < Minitest::Test

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class ErrorsTest < Minitest::Test

--- a/test/geo_shape_test.rb
+++ b/test/geo_shape_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class GeoShapeTest < Minitest::Test

--- a/test/highlight_test.rb
+++ b/test/highlight_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class HighlightTest < Minitest::Test

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class IndexTest < Minitest::Test

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class InheritanceTest < Minitest::Test

--- a/test/language_test.rb
+++ b/test/language_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class LanguageTest < Minitest::Test

--- a/test/marshal_test.rb
+++ b/test/marshal_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class MarshalTest < Minitest::Test

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class MatchTest < Minitest::Test

--- a/test/misspellings_test.rb
+++ b/test/misspellings_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class MisspellingsTest < Minitest::Test

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class ModelTest < Minitest::Test

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class MultiSearchTest < Minitest::Test

--- a/test/multi_tenancy_test.rb
+++ b/test/multi_tenancy_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class MultiTenancyTest < Minitest::Test

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class OrderTest < Minitest::Test

--- a/test/pagination_test.rb
+++ b/test/pagination_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class PaginationTest < Minitest::Test

--- a/test/partial_reindex_test.rb
+++ b/test/partial_reindex_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class PartialReindexTest < Minitest::Test

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class QueryTest < Minitest::Test

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class ReindexTest < Minitest::Test

--- a/test/reindex_v2_job_test.rb
+++ b/test/reindex_v2_job_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class ReindexV2JobTest < Minitest::Test

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class RoutingTest < Minitest::Test

--- a/test/should_index_test.rb
+++ b/test/should_index_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class ShouldIndexTest < Minitest::Test

--- a/test/similar_test.rb
+++ b/test/similar_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class SimilarTest < Minitest::Test

--- a/test/sql_test.rb
+++ b/test/sql_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class SqlTest < Minitest::Test

--- a/test/suggest_test.rb
+++ b/test/suggest_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class SuggestTest < Minitest::Test

--- a/test/synonyms_test.rb
+++ b/test/synonyms_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class SynonymsTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/setup"
 Bundler.require(:default)
 require "minitest/autorun"

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 class WhereTest < Minitest::Test


### PR DESCRIPTION
The adding of the frozen literal string will reduce the amount of
memory needed due the String imutabilty.
Works only on Ruby 2.3+, ignored on others.