### PR TITLE
Add time zone to date histogram

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -715,11 +715,12 @@ module Searchkick
           }
         elsif (histogram = agg_options[:date_histogram])
           interval = histogram[:interval]
+          time_zone = histogram[:time_zone].present? ? { time_zone: histogram[:time_zone] } : {}
           payload[:aggs][field] = {
             date_histogram: {
               field: histogram[:field],
               interval: interval
-            }
+            }.merge(time_zone)
           }
         elsif (metric = @@metric_aggs.find { |k| agg_options.has_key?(k) })
           payload[:aggs][field] = {


### PR DESCRIPTION
I was working on an aggregation view by day, where the day buckets were relative to the user's time zone. I discovered Searchkick didn't support the [Elasticsearch feature](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#_time_zone_2) where you can pass in a `time_zone` argument when doing aggregations.

I've added support for it, and I also added a test for the usage of the time zone attribute. Hope this can help others!

Let me know if you'd like me to clean up the test or implementation in any way.

