### PR TITLE
Batch with record_ids instead of bounds

### DIFF
--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -86,13 +86,13 @@ module Searchkick
       if scope.respond_to?(:primary_key)
         # TODO expire Redis key
         primary_key = scope.primary_key
+        primary_key_type = scope.columns_hash[primary_key].type
 
-        starting_id =
-          begin
-            scope.minimum(primary_key)
-          rescue ActiveRecord::StatementInvalid
-            false
-          end
+        starting_id = if with_bounds && primary_key_type == :integer
+          scope.minimum(primary_key)
+        else
+          false
+        end
 
         if starting_id.nil?
           # no records, do nothing
@@ -166,6 +166,10 @@ module Searchkick
 
     def batch_size
       @batch_size ||= index.options[:batch_size] || 1000
+    end
+
+    def with_bounds
+      @with_bounds ||= index.options[:with_bounds] || true
     end
   end
 end


### PR DESCRIPTION
When trying to reindex a model that has a non-sequential primary key `id`, but the primary key _is_ numeric, there is an issue when async reindexing - the number of jobs becomes extremely large and often doesn't cover more than a handful of actual ids. 

This feature allows optionally using record_ids instead of min_id and max_id in the async job, even if the scope's primary id is numeric.

The default is to use existing functionality.

For reference: https://github.com/ankane/searchkick/issues/1151
