### PR TITLE
Add unscoped to  for soft deletion

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -190,7 +190,7 @@ module Searchkick
     records =
       if records.respond_to?(:primary_key)
         # ActiveRecord
-        records.where(records.primary_key => ids) if records.primary_key
+        records.unscoped.where(records.primary_key => ids) if records.primary_key
       elsif records.respond_to?(:queryable)
         # Mongoid 3+
         records.queryable.for_ids(ids)


### PR DESCRIPTION
I have soft_deletion in my project

```
class Order < ActiveRecord::Base
    has_soft_deletion default_scope: true
end
```

I can find indexes, but mapping no data, because `load_records` it didn't unscoped.