### PR TITLE
fix: prevent generate duplicate field from suggest field (string/symbol)

### DIFF
--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -61,8 +61,8 @@ module Searchkick
       # hack to prevent generator field doesn't exist error
       if !partial_reindex
         index.suggest_fields.each do |field|
-          if !source[field] && !source[field.to_sym]
-            source[field] = nil
+          if (source.keys & [field, field.to_sym]).empty?
+	          source[field] = nil
           end
         end
       end


### PR DESCRIPTION
Issue:
When the value of **suggest filed is nill**, searchkick reindex task will create two duplicate fields in query parameters. And also will get an error from Elasticsearch below:

```
Searchkick::ImportError: {"type"=>"mapper_parsing_exception", "reason"=>"failed to parse", "caused_by"=>{"type"=>"json_parse_exception", "reason"=>"Duplicate field 'suggest_field'\n at [Source: org.elasticsearch.common.bytes.BytesReference$MarkSupportingStreamInputWrapper@62b97d8e; line: 1, column: 163]"}} on item with id '653'
```

Example:

```ruby
class Person < ActiveRecord::Base
  searchkick suggest: [:suggest_field]

  def search_data
    {
      name: name,
      suggest_field: suggest_field
    }
  end
end
```
(The suggest_filed's value in database is NULL )
When run the reindex task, the parameters in the query will like this:

```
 {:index=>
   {:_index=>"locales_development_20180607231727213",
    :_id=>653,
    :_type=>"person",
    :data=>
     {:name=>nil,
      :suggest_field=>nil,
      "suggest_field"=>nil}}},
```
You can find two suggest_field in the hash. One is string, another is symbol. 
The string is generate by the method `search_data` in RecordData.

My PR is to fix this duplicate issue.