### PR TITLE
Elasticsearch Scroll API

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ View with will_paginate
 <%= will_paginate @products %>
 ```
 
+### Scroll API
+
+For large datasets, a scroll context is more efficient than deep pagination. Create a scroll context by passing in the desired keep-alive time and the number of records per page
+
+```ruby
+products = Product.search "milk", per_page: 10, scroll: '1m'
+```
+
+Request the next set of records in the scroll context
+
+```ruby
+next_records = products.scroll
+``` 
+
 ### Partial Matches
 
 By default, results must match all words in the query.

--- a/lib/searchkick/logging.rb
+++ b/lib/searchkick/logging.rb
@@ -167,7 +167,9 @@ module Searchkick
 
       # no easy way to tell which host the client will use
       host = Searchkick.client.transport.hosts.first
-      debug "  #{color(name, YELLOW, true)}  curl #{host[:protocol]}://#{host[:host]}:#{host[:port]}/#{CGI.escape(index)}#{type ? "/#{type.map { |t| CGI.escape(t) }.join(',')}" : ''}/_search?pretty -H 'Content-Type: application/json' -d '#{payload[:query][:body].to_json}'"
+      params = ['pretty']
+      params << 'scroll=' + payload[:query][:scroll] if payload[:query][:scroll]
+      debug "  #{color(name, YELLOW, true)}  curl #{host[:protocol]}://#{host[:host]}:#{host[:port]}/#{CGI.escape(index)}#{type ? "/#{type.map { |t| CGI.escape(t) }.join(',')}" : ''}/_search?#{params.join('&')} -H 'Content-Type: application/json' -d '#{payload[:query][:body].to_json}'"
     end
 
     def request(event)

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -12,14 +12,14 @@ module Searchkick
       :took, :error, :model_name, :entry_name, :total_count, :total_entries,
       :current_page, :per_page, :limit_value, :padding, :total_pages, :num_pages,
       :offset_value, :offset, :previous_page, :prev_page, :next_page, :first_page?, :last_page?,
-      :out_of_range?, :hits, :response, :to_a, :first
+      :out_of_range?, :hits, :response, :to_a, :first, :scroll
 
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :body, :body_options, :boost,
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :execute, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
         :match, :misspellings, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :scope_results, :select, :similar, :smart_aggs, :suggest, :track, :type, :where]
+        :request_params, :routing, :scope_results, :select, :similar, :smart_aggs, :suggest, :track, :type, :where, :scroll]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s
@@ -71,6 +71,7 @@ module Searchkick
       }
       params[:type] = @type if @type
       params[:routing] = @routing if @routing
+      params[:scroll] = @scroll if @scroll
       params.merge!(options[:request_params]) if options[:request_params]
       params
     end
@@ -98,7 +99,9 @@ module Searchkick
       # no easy way to tell which host the client will use
       host = Searchkick.client.transport.hosts.first
       credentials = host[:user] || host[:password] ? "#{host[:user]}:#{host[:password]}@" : nil
-      "curl #{host[:protocol]}://#{credentials}#{host[:host]}:#{host[:port]}/#{CGI.escape(index)}#{type ? "/#{type.map { |t| CGI.escape(t) }.join(',')}" : ''}/_search?pretty -H 'Content-Type: application/json' -d '#{query[:body].to_json}'"
+      params = ['pretty']
+      params << 'scroll=' + options[:scroll] if options[:scroll]
+      "curl #{host[:protocol]}://#{credentials}#{host[:host]}:#{host[:port]}/#{CGI.escape(index)}#{type ? "/#{type.map { |t| CGI.escape(t) }.join(',')}" : ''}/_search?#{params.join('&')} -H 'Content-Type: application/json' -d '#{query[:body].to_json}'"
     end
 
     def handle_response(response)
@@ -116,7 +119,8 @@ module Searchkick
         misspellings: @misspellings,
         term: term,
         scope_results: options[:scope_results],
-        index_name: options[:index_name]
+        index_name: options[:index_name],
+        scroll: options[:scroll]
       }
 
       if options[:debug]
@@ -217,6 +221,7 @@ module Searchkick
       per_page = (options[:limit] || options[:per_page] || 10_000).to_i
       padding = [options[:padding].to_i, 0].max
       offset = options[:offset] || (page - 1) * per_page + padding
+      scroll = options[:scroll]
 
       # model and eager loading
       load = options[:load].nil? ? true : options[:load]
@@ -460,6 +465,12 @@ module Searchkick
         payload[:from] = offset
       end
 
+      # scroll
+      if scroll
+        payload[:size] = per_page
+        payload.delete(:from) # Offset (from) is not allowed in a scroll context
+      end
+
       # type
       if !searchkick_options[:inheritance] && (options[:type] || (klass != searchkick_klass && searchkick_index))
         @type = [options[:type] || klass].flatten.map { |v| searchkick_index.klass_document_type(v) }
@@ -476,6 +487,7 @@ module Searchkick
       @per_page = per_page
       @padding = padding
       @load = load
+      @scroll = scroll
     end
 
     def set_fields

--- a/test/scroll_test.rb
+++ b/test/scroll_test.rb
@@ -1,0 +1,128 @@
+require_relative "test_helper"
+
+class ScrollTest < Minitest::Test
+  def test_limit
+    store_names ["Product A", "Product B", "Product C", "Product D"]
+    assert_order "product", ["Product A", "Product B"], order: {name: :asc}, limit: 2
+  end
+
+  def test_no_limit
+    names = 20.times.map { |i| "Product #{i}" }
+    store_names names
+    assert_search "product", names
+  end
+
+  def test_offset
+    store_names ["Product A", "Product B", "Product C", "Product D"]
+    assert_order "product", ["Product C", "Product D"], order: {name: :asc}, offset: 2, limit: 100
+  end
+
+  def test_scroll
+    store_names ["Product A", "Product B", "Product C", "Product D", "Product E", "Product F"]
+    products = Product.search("product", order: {name: :asc}, scroll: '1m', per_page: 2)
+    assert_equal ["Product A", "Product B"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    assert_equal "1m", products.options[:scroll]
+    assert_equal products.response["_scroll_id"], products.scroll_id
+    assert_nil products.current_page
+    assert_nil products.padding
+    assert_nil products.per_page
+    assert_equal 2, products.size
+    assert_equal 2, products.length
+    assert_nil products.total_pages
+    assert_equal 6, products.total_count
+    assert_equal 6, products.total_entries
+    assert_nil products.limit_value
+    assert_nil products.offset_value
+    assert_nil products.offset
+    assert_nil products.next_page
+    assert_nil products.previous_page
+    assert_nil products.prev_page
+    assert !products.first_page?
+    assert !products.last_page?
+    assert !products.empty?
+    assert !products.out_of_range?
+    assert products.any?
+
+    # scroll for next 2
+    products = products.scroll
+    assert_equal ["Product C", "Product D"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    # scroll for next 2
+    products = products.scroll
+    assert_equal ["Product E", "Product F"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    # scroll exhausted
+    products = products.scroll
+    assert_equal [], products.map(&:name)
+    assert_equal "product", products.entry_name
+  end
+
+  def test_scroll_body
+    store_names ["Product A", "Product B", "Product C", "Product D", "Product E", "Product F"]
+    products = Product.search("product", body: {query: {match_all: {}}, sort: [{name: "asc"}]}, scroll: '1m', per_page: 2)
+    assert_equal ["Product A", "Product B"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    assert_equal "1m", products.options[:scroll]
+    assert_equal products.response["_scroll_id"], products.scroll_id
+    assert_nil products.current_page
+    assert_nil products.padding
+    assert_nil products.per_page
+    assert_equal 2, products.size
+    assert_equal 2, products.length
+    assert_nil products.total_pages
+    assert_equal 6, products.total_count
+    assert_equal 6, products.total_entries
+    assert_nil products.limit_value
+    assert_nil products.offset_value
+    assert_nil products.offset
+    assert_nil products.next_page
+    assert_nil products.previous_page
+    assert_nil products.prev_page
+    assert !products.first_page?
+    assert !products.last_page?
+    assert !products.empty?
+    assert !products.out_of_range?
+    assert products.any?
+
+    # scroll for next 2
+    products = products.scroll
+    assert_equal ["Product C", "Product D"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    # scroll for next 2
+    products = products.scroll
+    assert_equal ["Product E", "Product F"], products.map(&:name)
+    assert_equal "product", products.entry_name
+    # scroll exhausted
+    products = products.scroll
+    assert_equal [], products.map(&:name)
+    assert_equal "product", products.entry_name
+  end
+
+  def test_scroll_nil_scroll
+    store_names ["Product A", "Product B", "Product C", "Product D", "Product E"]
+    products = Product.search("product", order: {name: :asc}, scroll: nil, per_page: 2)
+    assert_equal ["Product A", "Product B"], products.map(&:name)
+    assert_equal 1, products.current_page
+    assert products.first_page?
+    assert_nil products.options[:scroll]
+    assert_nil products.scroll_id
+  end
+
+  def test_kaminari
+    skip unless defined?(Kaminari)
+
+    require "action_view"
+
+    I18n.load_path = Dir["test/support/kaminari.yml"]
+    I18n.backend.load_translations
+
+    view = ActionView::Base.new
+
+    store_names ["Product A"]
+    assert_equal "Displaying <b>1</b> product", view.page_entries_info(Product.search("product"))
+
+    store_names ["Product B"]
+    assert_equal "Displaying <b>all 2</b> products", view.page_entries_info(Product.search("product"))
+  end
+end


### PR DESCRIPTION
## What's up

* We were running into similar problems to #642 but found that simply increasing the result window was not a viable solution

## What this does

* Adds support for [Elasticsearch Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html)
* Allows users to pass in the `scroll` param to initiate a scroll context
* Stores the `scroll_id` on the `Searchkick::Results` object
* Exposes a `scroll` method on `Searchkick::Results` to request the next batch of results
* `nils` out pagination-related methods if using a scroll context

## Notes

* Since the Scroll API uses a URL param, I wasn't quite sure how to represent that in `Searchkick::Query` so I just followed what was already there for pagination
* I force delete  the `from` attribute in the payload because Scroll Contexts do not allow that parameter
* I wasn't sure of the protocol of using the `Searchkick.client` from within the `Searchkick::Results` object. Is this allowed?