### PR TITLE
Fix the total docs call after import logic move

### DIFF
--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -24,7 +24,7 @@ module Searchkick
           # to get the max _id without scripting since it's a string
 
           # TODO use primary key and prefix with table name
-          relation = relation.where("id > ?", total_docs)
+          relation = relation.where("id > ?", index.total_docs)
         end
 
         relation = relation.select("id").except(:includes, :preload) if async


### PR DESCRIPTION
Hi folks,

When I tried to reindex with `resume`, the error raises:
```ruby
NameError: undefined local variable or method `total_docs' for #<Searchkick::BulkIndexer:0x007ff78b9b2168>
```

I believe that the erro was introduced after the import logic move on commit fd936e493ec46909171a849d9f4ed68130ede7ec.

Thanks :)