### PR TITLE
Adds a :multiple option for searching with :highlight for .search_highlights with multiple results

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -38,7 +38,8 @@ module Searchkick
               result = results[hit["_type"]][hit["_id"].to_s]
               if result && !(options[:load].is_a?(Hash) && options[:load][:dumpable])
                 if (hit["highlight"] || options[:highlight]) && !result.respond_to?(:search_highlights)
-                  highlights = hit_highlights(hit)
+                  multiple = options[:highlight].is_a?(Hash) && options[:highlight][:multiple]
+                  highlights = hit_highlights(hit, multiple: multiple)
                   result.define_singleton_method(:search_highlights) do
                     highlights
                   end

--- a/test/highlight_test.rb
+++ b/test/highlight_test.rb
@@ -87,6 +87,17 @@ class HighlightTest < Minitest::Test
     end
   end
 
+  def test_searchkick_highlights_singleton_with_multiple_option
+    store_names ["Two Door Cinema Club Some Other Words And Much More Doors Cinema Club"]
+    highlights = Product.search("cinema", highlight: {fragment_size: 20, multiple: true}).first.search_highlights[:name]
+    assert highlights.is_a?(Array)
+    assert_equal highlights.count, 2
+    refute_equal highlights.first, highlights.last
+    highlights.each do |highlight|
+      assert highlight.include?("<em>Cinema</em>")
+    end
+  end
+
   def test_search_highlights_method
     store_names ["Two Door Cinema Club"]
     assert_equal "Two Door <em>Cinema</em> Club", Product.search("cinema", highlight: true).first.search_highlights[:name]


### PR DESCRIPTION
Currently you can already retrieve multiple highlights like this:

```ruby
bands = Band.search "cinema", highlight: {fragment_size: 20}
bands.with_highlights(multiple: true).each do |band, highlights|
  highlights[:name].join(" and ")
end
```

Sadly this approach leads to quite complex rendering and view handling (because you cannot directly loop the records but have to loop an array of `[record, highlight]`). 

Because of that i normally use the method `.search_highlights` on `record` that is automatically defined by searchkick. This PR also enables the `multiple` behaviour of `.with_highlights` for the `.search_highlights` method by simply specifying a `multiple` option when searching. Example:

```ruby
Product.search("cinema", highlight: {fragment_size: 20, multiple: true})
```

Using `record.search_highlights` in the view then returns multiple highlights just like `.with_highlights` does.