### PR TITLE
Add support for script option in aggregations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,12 @@ Minimum document count
 Product.search "apples", aggs: {store_id: {min_doc_count: 2}}
 ```
 
+Script support
+
+```ruby
+Product.search "*", aggs: {color: {script: {source: "'Color: ' + _value"}}}
+```
+
 Date histogram
 
 ```ruby

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -736,7 +736,7 @@ module Searchkick
       aggs = Hash[aggs.map { |f| [f, {}] }] if aggs.is_a?(Array) # convert to more advanced syntax
       aggs.each do |field, agg_options|
         size = agg_options[:limit] ? agg_options[:limit] : 1_000
-        shared_agg_options = agg_options.slice(:order, :min_doc_count)
+        shared_agg_options = agg_options.slice(:order, :min_doc_count, :script)
 
         if agg_options[:ranges]
           payload[:aggs][field] = {

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -34,6 +34,12 @@ class AggsTest < Minitest::Test
     assert_equal ({2 => 2}), store_agg(aggs: {store_id: {min_doc_count: 2}})
   end
 
+  def test_script
+    source = "'Color: ' + _value"
+    agg = Product.search("Product", aggs: {color: {script: {source: source}}}).aggs["color"]
+    assert_equal ({"Color: blue" => 1, "Color: green" => 1, "Color: red" => 1}), buckets_as_hash(agg)
+  end
+
   def test_no_aggs
     assert_nil Product.search("*").aggs
   end


### PR DESCRIPTION
Add support for `script` in aggregations.
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_value_script_8

Usage example:

```
source =  "'Color: ' + _value"
Product.search "*", aggs: { color: { script: { source: source, lang: "painless" } } }
```