### PR TITLE
[Feature Request and Proposal] Add ability to search by prefix to where syntax

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -895,6 +895,8 @@ module Searchkick
                     }
                   }
                 }
+              when :prefix
+                filters << {prefix: {field => op_value}}
               when :regexp # support for regexp queries without using a regexp ruby object
                 filters << {regexp: {field => {value: op_value}}}
               when :not, :_not # not equal

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -74,6 +74,11 @@ class WhereTest < Minitest::Test
     assert_search "*", ["Product A"], where: {name: /Pro.+/}
   end
 
+  def test_prefix
+    store_names ["Product A", "Product B", "Item C"]
+    assert_search "*", ["Product A", "Product B"], where: { name: { prefix: 'Pro'}}
+  end
+
   def test_alternate_regexp
     store_names ["Product A", "Item B"]
     assert_search "*", ["Product A"], where: {name: {regexp: "Pro.+"}}


### PR DESCRIPTION
Motivation: Use the elasticsearch prefix syntax as part of building a semi-complex where query but don't want to move into pure elasticsearch syntax yet.

allows direct leveraging of https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html

Co-authored-by: Jonathan Wrobel <jonathan.wrobel@omadahealth.com>