### PR TITLE
Fix bug wrong number of arguments when run async job

### DIFF
--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -2,7 +2,13 @@ module Searchkick
   class BulkReindexJob < ActiveJob::Base
     queue_as { Searchkick.queue_name }
 
-    def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)
+    def perform(*args)
+      args.each { |arg| job(arg.symbolize_keys) }
+    end
+
+    private
+
+    def job(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)
       klass = class_name.constantize
       index = index_name ? Searchkick::Index.new(index_name, **klass.searchkick_options) : klass.searchkick_index
       record_ids ||= min_id..max_id


### PR DESCRIPTION
# Bugs
- Sometimes we have this bug. I think this problem come from the way we handle active_job

```
ArgumentError: wrong number of arguments (given 1, expected 0)
/Users/duclinh/.rvm/gems/ruby-2.3.4/gems/searchkick-2.3.0/lib/searchkick/bulk_reindex_job.rb:5:in `perform'
/Users/duclinh/.rvm/gems/ruby-2.3.4/gems/activejob-4.2.0/lib/active_job/execution.rb:32:in `block in perform_now'
```

- It related to https://github.com/ankane/searchkick/issues/1201

# How to re-produce bug
- ruby version: 2.3.4
- searchkick version 2.3.0
- active job version 4.2.0
- reindex with async is true. Ex. `Photo.reindex(async: true)`
# Causes

- Our function

```ruby
def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)
  klass = class_name.constantize
  index = index_name ? Searchkick::Index.new(index_name, **klass.searchkick_options) : klass.searchkick_index
  record_ids ||= min_id..max_id
  index.import_scope(
    Searchkick.load_records(klass, record_ids),
    method_name: method_name,
    batch: true,
    batch_id: batch_id
  )
end
```

- into ActiveJob we have function - https://github.com/rails/rails/blob/master/activejob/lib/active_job/execution.rb#L39

```ruby
  def perform_now
    deserialize_arguments_if_needed
    run_callbacks :perform do
      perform(*arguments)
    end
  rescue => exception
    rescue_with_handler(exception) || raise(exception)
  end
```

- arguments will be like

```
[{"class_name"=>"Photo", "index_name"=>"photos_development_20181023130950696", "batch_id"=>1, "min_id"=>2, "max_id"=>1001}]
```

- the problem is current arguments is hash with string keys not symbol key

# Todo
- [IMO] we need to convert another like `ProcessBatchJob` and `ReindexV2Job` to make it stable. This PR only one of them. What do you think about that?
