### PR TITLE
Remove Japanese stemmer that does not exist

### DIFF
--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -180,6 +180,8 @@ module Searchkick
               type: "kuromoji"
             }
           )
+
+          settings[:analysis][:filter].delete(:searchkick_stemmer)
         when "korean"
           settings[:analysis][:analyzer].merge!(
             default_analyzer => {


### PR DESCRIPTION
Removed Japanese stemmer in `index_options.rb` because Japanese stemmer does not exist in [the list](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-stemmer-tokenfilter.html). It is the same as Chinese ([index_options.rb#L170](https://github.com/ankane/searchkick/blob/36e96d79f2cf841cb0798fbbf1d42b3d3b48e49d/lib/searchkick/index_options.rb#L170)).

Elasticsearch `6.5.x` raises an exception when creating invalid stemmers, but `6.4.x` doesn't. Maybe it was caused by https://github.com/elastic/elasticsearch/pull/34601