### PR TITLE
Removes unecessary if clause in query.rb

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -384,15 +384,8 @@ module Searchkick
             end
           end
 
-          # all + exclude option
-          if all
+          if !all
             query = {
-              match_all: {}
-            }
-
-            should = []
-          else
-            payload = {
               dis_max: {
                 queries: queries
               }
@@ -400,8 +393,6 @@ module Searchkick
 
             should.concat(set_conversions)
           end
-
-          query = payload
         end
 
         payload = {}


### PR DESCRIPTION
In reviewing this file to see about adding support for `simple_string_query` I noticed some code that doesn't seem to be used (unless I'm missing something that's right in front of me 🤦‍♂️).


As far as add `simple_string_query`, I can add an issue to discuss, but curious what your thoughts are about adding some support in a similar way you support all without the `exclude` option:

```ruby
elsif all && !options[:exclude]
  query = {
    match_all: {}
  }
...
```

Something like:

```ruby
elsif options[:simple_string_query]
	query = {
      simple_string_query: {
	  	query: term,
        default_operator: operator
      }
    }
```

OR

Maybe allow a `query_options` option that is similar to `body_options` but just replaces the query? I know we can use the advanced querying, but I'd like to continue to have Searchkick manage filters and pagination while also using `simple_search_query`