### PR TITLE
Implements simple_query_string option

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -19,7 +19,7 @@ module Searchkick
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :execute, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
         :match, :misspellings, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :scope_results, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where]
+        :request_params, :routing, :scope_results, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where, :simple_query_string]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s
@@ -236,7 +236,16 @@ module Searchkick
         must_not = []
         should = []
 
-        if options[:similar]
+        if options[:simple_query_string]
+          query = {
+            simple_query_string: {
+              query: term,
+              default_operator: operator,
+              fields: fields,
+              analyze_wildcard: true
+            }
+          }
+        elsif options[:similar]
           query = {
             more_like_this: {
               like: term,

--- a/test/simple_query_string_test.rb
+++ b/test/simple_query_string_test.rb
@@ -1,0 +1,71 @@
+require_relative "test_helper"
+
+class SimpleQueryStringTest < Minitest::Test
+  def test_simple_query_string_query_body
+    store_names ["Milk", "Apple Juice", "Juice"]
+
+    query = Product.search("apple +juice | milk", simple_query_string: true, execute: false)
+
+    expected_query = {
+      simple_query_string: {
+        query: "apple +juice | milk",
+        default_operator: "and",
+        fields: ["*.analyzed"],
+        analyze_wildcard:true
+        }
+      }
+
+    assert_equal expected_query, query.body[:query]
+  end
+
+  def test_and
+    store_names ["Milk", "Apple Juice", "Juice"]
+    results = Product.search("apple +juice", simple_query_string: true)
+
+    assert_equal ["Apple Juice"], results.map(&:name)
+  end
+
+  def test_or
+    store_names ["Milk", "Apple Juice", "Juice"]
+    results = Product.search("apple | juice", simple_query_string: true)
+
+    assert_equal ["Apple Juice", "Juice"], results.map(&:name).sort
+  end
+
+  def test_and_or
+    store_names ["Milk", "Apple Juice", "Juice"]
+    results = Product.search("apple + juice | milk", simple_query_string: true)
+
+    assert_equal ["Apple Juice", "Milk"], results.map(&:name).sort
+  end
+
+  def test_exclude
+    store_names ["Milk", "Apple Juice", "Juice"]
+    results = Product.search("juice | milk -apple", simple_query_string: true)
+
+    assert_equal ["Juice", "Milk"], results.map(&:name).sort
+  end
+
+  def test_with_order
+    store_names ["Milk", "Apple Juice", "Juice"]
+    results = Product.search("apple | juice", simple_query_string: true, order: { name: :asc })
+
+    assert_equal ["Apple Juice", "Juice"], results.map(&:name)
+
+    results = Product.search("apple | juice", simple_query_string: true, order: { name: :desc })
+
+    assert_equal ["Juice", "Apple Juice"], results.map(&:name)
+  end
+
+  def test_with_pagination
+    store_names ["Milk", "Apple Juice", "Juice"]
+
+    results = Product.search("apple + juice | milk", simple_query_string: true, limit: 1, order: { name: :desc })
+
+    assert_equal ["Milk"], results.map(&:name)
+
+    results = Product.search("apple + juice | milk", simple_query_string: true, limit: 1, page: 2, order: { name: :desc })
+
+    assert_equal ["Apple Juice"], results.map(&:name)
+  end
+end


### PR DESCRIPTION
I'm guessing this may be a naive approach to implementing this feature, but thought I'd give it a shot. I know we can use the `body` option to do more advanced queries, including `simple_query_string` queries, but it would be nice to have a way to do it without having to also manage where clauses, pagination, timeouts etc.

I thought another solution to this might be to have a `query_options` option that takes a proc that can inject a query into the other options, but I just needed `simple_query_string` so I went for that.

Let me know what ya'll think!

[implements-simple-query-string]