### PR TITLE
Automatically requeue bulk rejections

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -32,7 +32,9 @@ module Searchkick
   class UnsupportedVersionError < Error; end
   class InvalidQueryError < Elasticsearch::Transport::Transport::Errors::BadRequest; end
   class DangerousOperation < Error; end
-  class ImportError < Error; end
+  class ImportError < Error
+    attr_accessor :failures
+  end
 
   class << self
     attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options

--- a/lib/searchkick/reindex_queue.rb
+++ b/lib/searchkick/reindex_queue.rb
@@ -8,8 +8,8 @@ module Searchkick
       raise Searchkick::Error, "Searchkick.redis not set" unless Searchkick.redis
     end
 
-    def push(record_id)
-      Searchkick.with_redis { |r| r.lpush(redis_key, record_id) }
+    def push(record_ids)
+      Searchkick.with_redis { |r| r.lpush(redis_key, Array(record_ids)) }
     end
 
     # TODO use reliable queuing

--- a/test/indexer_test.rb
+++ b/test/indexer_test.rb
@@ -1,0 +1,59 @@
+require_relative "test_helper"
+
+class IndexerTest < Minitest::Test
+  def test_bulk_index_raises_rejection
+    error_response = {
+      "took" => 15,
+      "errors" => true,
+      "items" => [
+        {
+          "index" => {
+            "_index" => "foo",
+            "_type" => "user",
+            "_id" => "3330",
+            "_version" => 13,
+            "_shards" => {
+              "total" => 2,
+              "successful" => 1,
+              "failed" => 0
+            },
+            "status" => 200
+          }
+        },
+        {
+          "index" => {
+            "_index" => "foo",
+            "_type" => "user",
+            "_id" => "3545",
+            "status" => 429,
+            "error" => {
+              "type" => "es_rejected_execution_exception",
+              "reason" => "rejected execution of org.elasticsearch.transport.TransportService$4@14d0f204 on EsThreadPoolExecutor[bulk, queue capacity = 1, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@2d0fb6d4[Running, pool size = 1, active threads = 1, queued tasks = 1, completed tasks = 18]]"
+            }
+          }
+        }
+      ]
+    }
+
+    items = [
+      {
+        :index => {
+          :_index => "foo",
+          :_id => 3330,
+          :_type => "user",
+          :data => {
+            "id" => 3330,
+          }
+        }
+      }
+    ]
+
+    Searchkick.client.stub :bulk, error_response do
+      e = assert_raises Searchkick::ImportError do
+        Searchkick::Indexer.new.queue(items)
+      end
+
+      assert_equal 1, e.failures.size
+    end
+  end
+end

--- a/test/process_batch_job_test.rb
+++ b/test/process_batch_job_test.rb
@@ -1,0 +1,48 @@
+require_relative "test_helper"
+
+class ProcessBatchJobTest < Minitest::Test
+  def setup
+    skip unless defined?(ActiveJob)
+    Product.search_index.reindex_queue.clear
+    super
+  end
+
+  def test_bulk_index
+    product = Searchkick.callbacks(false) { Product.create!(name: "Boom") }
+    Product.search_index.refresh
+    assert_search "*", []
+    Searchkick::ProcessBatchJob.new.perform(class_name: "Product", record_ids: [product.id.to_s])
+    Product.search_index.refresh
+    assert_search "*", ["Boom"]
+  end
+
+  def test_bulk_index_handles_rejection
+    product = Searchkick.callbacks(false) { Product.create!(name: "Boom") }
+
+    error_response = {
+      "took" => 15,
+      "errors" => true,
+      "items" => [
+        {
+          "index" => {
+            "_index" => "foo",
+            "_type" => "product",
+            "_id" => product.id.to_s,
+            "status" => 429,
+            "error" => {
+              "type" => "es_rejected_execution_exception",
+              "reason" => "rejected execution of org.elasticsearch.transport.TransportService$4@14d0f204 on EsThreadPoolExecutor[bulk, queue capacity = 1, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@2d0fb6d4[Running, pool size = 1, active threads = 1, queued tasks = 1, completed tasks = 18]]"
+            }
+          }
+        }
+      ]
+    }
+    assert_equal 0, Product.search_index.reindex_queue.length
+    Searchkick.client.stub :bulk, error_response do
+      Searchkick::ProcessBatchJob.new.perform(class_name: "Product", record_ids: [product.id.to_s])
+    end
+    assert_equal 1, Product.search_index.reindex_queue.length
+    id = Product.search_index.reindex_queue.reserve.first
+    assert_equal product.id.to_s, id
+  end
+end


### PR DESCRIPTION
In a busy ES cluster with lots of write activity, using the `bulk` callback method, it is highly likely to see lots of these guys:

```
Searchkick::ImportError: {"type"=>"es_rejected_execution_exception", "reason"=>"rejected execution of org.elasticsearch.transport.TransportService$4@f1e9eea on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@46cb2258[Running, pool size = 2, active threads = 2, queued tasks = 50, completed tasks = 1234]]"} on item with id '1234'
```

When a bulk rejection of this kind occurs, it is possible that _some_ of the operations succeeded and _some_ of them failed. According to the docs on [thread pools](https://www.elastic.co/guide/en/elasticsearch/guide/current/_monitoring_individual_nodes.html#_threadpool_section), what we'd like to do is check the response from ES and retry just the failures.

Prior to this change, the job would raise an exception and attempt to index 100% of the items that were part of the job, regardless of initial success.

After this change, the items that succeeded are considered done and the items that failed are added back to the bulk queue to get picked up the next time a `ProcessQueueJob` runs.