### PR TITLE
Add stats aggs

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -2,7 +2,7 @@ module Searchkick
   class Query
     extend Forwardable
 
-    @@metric_aggs = [:avg, :cardinality, :max, :min, :sum]
+    @@metric_aggs = [:avg, :cardinality, :max, :min, :sum, :stats, :extended_stats]
 
     attr_reader :klass, :term, :options
     attr_accessor :body

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -178,6 +178,34 @@ class AggsTest < Minitest::Test
     assert_equal 3, products.aggs["total_stores"]["value"]
   end
 
+  def test_aggs_stats
+    products =
+      Product.search("*", {
+        aggs: {
+          price_stats: {
+            stats: {
+              field: :price
+            }
+          }
+        }
+      })
+    assert_equal 66, products.aggs["price_stats"]["sum"]
+  end
+
+  def test_aggs_extended_stats
+    products =
+      Product.search("*", {
+        aggs: {
+          price_extended_stats: {
+            extended_stats: {
+              field: :price
+            }
+          }
+        }
+      })
+    assert_equal 1316, products.aggs["price_extended_stats"]["sum_of_squares"]
+  end
+
   def test_aggs_min_max
     products =
       Product.search("*", {


### PR DESCRIPTION
ES has had support for stats aggregations for a while. This adds proper support with two new allowed keywords.

https://www.elastic.co/guide/en/elasticsearch/reference/6.6/search-aggregations-metrics-stats-aggregation.html

https://www.elastic.co/guide/en/elasticsearch/reference/6.6/search-aggregations-metrics-extendedstats-aggregation.html
