### PR TITLE
support include_type_name

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -13,7 +13,12 @@ module Searchkick
     end
 
     def create(body = {})
-      client.indices.create index: name, body: body
+      include_type_name = body.delete(:include_type_name)
+      if include_type_name
+        client.indices.create index: name, body: body, include_type_name: include_type_name
+      else
+        client.indices.create index: name, body: body
+      end
     end
 
     def delete

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -4,6 +4,10 @@ module Searchkick
       options = @options
       language = options[:language]
       language = language.call if language.respond_to?(:call)
+      include_type_name = {}
+      if options[:include_type_name]
+        include_type_name.merge!(include_type_name: options[:include_type_name])
+      end
 
       if options[:mappings] && !options[:merge_mappings]
         settings = options[:settings] || {}
@@ -423,7 +427,7 @@ module Searchkick
       {
         settings: settings,
         mappings: mappings
-      }
+      }.merge(include_type_name)
     end
   end
 end

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -7,7 +7,7 @@ module Searchkick
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :language,
         :locations, :mappings, :match, :merge_mappings, :routing, :searchable, :settings, :similarity,
         :special_characters, :stem, :stem_conversions, :suggest, :synonyms, :text_end,
-        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start]
+        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start, :include_type_name]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       raise "Only call searchkick once per model" if respond_to?(:searchkick_index)


### PR DESCRIPTION
Elasticsearch 6.7 adds the include_type_name option for migration to v7.0.
Searchkick also supports include_type_name for smooth migration

https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html