### PR TITLE
Update Readme.md Heroku / foundelasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,16 +1038,19 @@ heroku addons:create foundelasticsearch
 heroku addons:open foundelasticsearch
 ```
 
-Visit the Shield page and reset your password. You’ll need to add the username and password to your url. Get the existing url with:
+Visit the Shield page and reset your password. You’ll need to add the username and password to your url.
+Also, verify your port number in your dashboard, It sould be `9243`
+
+Get the existing url with:
 
 ```sh
 heroku config:get FOUNDELASTICSEARCH_URL
 ```
 
-And add `elastic:password@` right after `https://`:
+And add `elastic:password@` right after `https://`, add the port at the end:
 
 ```sh
-heroku config:set ELASTICSEARCH_URL=https://elastic:password@12345.us-east-1.aws.found.io
+heroku config:set ELASTICSEARCH_URL=https://elastic:password@12345.us-east-1.aws.found.io:9243
 ```
 
 Then deploy and reindex:


### PR DESCRIPTION
For Heroku with plugin foundelasticsearch and last version.
I did the update today and got `Faraday::ConnectionFailed - SSL connect error` for each request after the deploy.
I don't know what changed in any dependency or even in searchkick but adding the port resolve the issue. It was working fine with earlier versions of`elasticsearch-ruby` and deps.

Maybe there is the same issue with bonsai addon, i don't know. Maybe someone should verify.