### PR TITLE
Restrict elasticsearch to be less than 7 for searchkick 3.x

### DIFF
--- a/searchkick.gemspec
+++ b/searchkick.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.2"
 
   spec.add_dependency "activemodel", ">= 4.2"
-  spec.add_dependency "elasticsearch", ">= 5"
+  spec.add_dependency "elasticsearch", ">= 5", "< 7"
   spec.add_dependency "hashie"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Got the error `Faraday::SSLError: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: unknown protocol` on our apps after upgrading the `elasticsearch` version from 6.3.1 to 7.1.0. (deployed on heroku using bonsai.io fwiw)

This does not happen locally perhaps because SSL is not used in that case.

After restricting `elasticsearch` to 6.x the problem went away. 
I think other people using searchkick 3.x (because they still use Rails 4, for example), might end up with the same problem.

The fix should be made against the 3.x branch, but since there isn't one, can a maintainer please create it?

ps: other dependencies are also open, and perhaps they all should be locked.
```
WARNING:  open-ended dependency on activemodel (>= 4.2) is not recommended
  if activemodel is semantically versioned, use:
    add_runtime_dependency 'activemodel', '~> 4.2'
WARNING:  open-ended dependency on hashie (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on minitest (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
```

