### PR TITLE
Add Rails >= 5 requirement to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add this line to your application’s Gemfile:
 gem 'searchkick'
 ```
 
-The latest version works with Elasticsearch 6 and 7. For Elasticsearch 5, use version 3.1.3 and [this readme](https://github.com/ankane/searchkick/blob/v3.1.3/README.md).
+The latest version works with Rails 5, Elasticsearch 6 and 7. For Rails 4 or Elasticsearch 5, use version 3.1.3 and [this readme](https://github.com/ankane/searchkick/blob/v3.1.3/README.md).
 
 Add searchkick to models you want to search.
 


### PR DESCRIPTION
Since Searchkick depends on `ActiveModel > 5` this version won't work on Rails 4 or below, updated readme accordingly.

related to #1262 