### PR TITLE
Fixed typo [index_options]

### DIFF
--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -13,7 +13,7 @@ module Searchkick
         index_type = index_type.call if index_type.respond_to?(:call)
       end
 
-      custom_mapping = options[:mapping] || {}
+      custom_mapping = options[:mappings] || {}
       if below70 && custom_mapping.keys.map(&:to_sym).include?(:properties)
         # add type
         custom_mapping = {index_type => custom_mapping}

--- a/test/index_options_test.rb
+++ b/test/index_options_test.rb
@@ -25,4 +25,8 @@ class IndexOptionsTest < Minitest::Test
       assert_search "jalapeno", [], {misspellings: false}, Song
     end
   end
+
+  def test_custom_mappings_with_merge_option
+    assert_equal Song.search_index.mapping.values.first['mappings']['properties']['lyrics']['type'], 'text'
+  end
 end

--- a/test/models/song.rb
+++ b/test/models/song.rb
@@ -1,5 +1,13 @@
 class Song
-  searchkick
+  mappings = {
+    properties: {
+      lyrics: {type: "text"}
+    }
+  }
+
+  searchkick \
+    merge_mappings: true,
+    mappings: mappings
 
   def search_routing
     name


### PR DESCRIPTION
It looks like typo but without this fix I can't configure custom mappings