### PR TITLE
Enable to query on locations not near to specific lon & lat

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -891,6 +891,17 @@ module Searchkick
               case op
               when :within, :bottom_right, :bottom_left
                 # do nothing
+              when :not_near
+                filters << {
+                  bool: {
+                    must_not: {
+                      geo_distance: {
+                        field => location_value(op_value),
+                        distance: value[:within] || "50mi"
+                      }
+                    }
+                  }
+                }  
               when :near
                 filters << {
                   geo_distance: {

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -178,12 +178,28 @@ class WhereTest < Minitest::Test
     assert_search "san", ["San Francisco"], where: {location: {near: [37.5, -122.5]}}
   end
 
+  def test_not_near
+    store [
+      {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
+      {name: "San Antonio", latitude: 29.4167, longitude: -98.5000}
+    ]
+    assert_search "san", ["San Antonio"], where: {location: {not_near: [37.5, -122.5]}}
+  end
+
   def test_near_hash
     store [
       {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
       {name: "San Antonio", latitude: 29.4167, longitude: -98.5000}
     ]
     assert_search "san", ["San Francisco"], where: {location: {near: {lat: 37.5, lon: -122.5}}}
+  end
+
+  def test_not_near_hash
+    store [
+      {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
+      {name: "San Antonio", latitude: 29.4167, longitude: -98.5000}
+    ]
+    assert_search "san", ["San Antonio"], where: {location: {not_near: {lat: 37.5, lon: -122.5}}}
   end
 
   def test_near_within
@@ -195,6 +211,15 @@ class WhereTest < Minitest::Test
     assert_search "san", ["San Francisco", "San Antonio"], where: {location: {near: [37, -122], within: "2000mi"}}
   end
 
+  def test_not_near_within
+    store [
+      {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
+      {name: "San Antonio", latitude: 29.4167, longitude: -98.5000},
+      {name: "San Marino", latitude: 43.9333, longitude: 12.4667}
+    ]
+    assert_search "san", ["San Marino"], where: {location: {not_near: [37, -122], within: "2000mi"}}
+  end
+
   def test_near_within_hash
     store [
       {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
@@ -202,6 +227,15 @@ class WhereTest < Minitest::Test
       {name: "San Marino", latitude: 43.9333, longitude: 12.4667}
     ]
     assert_search "san", ["San Francisco", "San Antonio"], where: {location: {near: {lat: 37, lon: -122}, within: "2000mi"}}
+  end
+
+  def test_not_near_within_hash
+    store [
+      {name: "San Francisco", latitude: 37.7833, longitude: -122.4167},
+      {name: "San Antonio", latitude: 29.4167, longitude: -98.5000},
+      {name: "San Marino", latitude: 43.9333, longitude: 12.4667}
+    ]
+    assert_search "san", ["San Marino"], where: {location: {not_near: {lat: 37, lon: -122}, within: "2000mi"}}
   end
 
   def test_geo_polygon


### PR DESCRIPTION
I ran into a problem which is I have products with their locations "longitude & latitude"based on their vendors.
And I have a page of products which has 2 sections, first section is the products that is near to user's location "which is supported by the gem" so he can buy them directly from the vendors.
the second section is the products that are not near to the user's location so user needs to ship this products with courier to get these products "which is not supported".
I've written unit tests. 

