### PR TITLE
Add match_phrase support to filters

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -1024,6 +1024,8 @@ module Searchkick
         end
 
         {regexp: {field => {value: source, flags: "NONE"}}}
+      elsif value.is_a?(String) && value[0] == '"' && value[-1] == '"'
+        {match_phrase: {field => {query: value[1..-2]}}}
       else
         {term: {field => value}}
       end

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -98,6 +98,16 @@ class WhereTest < Minitest::Test
     assert_search "*", ["Product A"], where: {name: {regexp: "Pro.+"}}
   end
 
+  def test_phrase
+    store_names ["the quick brown fox", "brown foxes are quick"]
+    assert_search '*', ["the quick brown fox"], where: {"name.analyzed": '"quick brown"'}
+  end
+
+  def test_alternate_regexp
+    store_names ["Product A", "Item B"]
+    assert_search "*", ["Product A"], where: {name: {regexp: "Pro.+"}}
+  end
+
   def test_special_regexp
     store_names ["Product <A>", "Item <B>"]
     assert_search "*", ["Product <A>"], where: {name: /\APro.+<.+\z/}


### PR DESCRIPTION
This is actually a bit janky (using quotes to signal a phrase match) but it works sort-of OK and does mostly what you'd expect (that is, `where: {body: '"three monkeys"'}` filters to documents containing those words together.
