### PR TITLE
[Idea] _raw filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,27 @@ where: {
   _or: [{in_stock: true}, {backordered: true}],
   _and: [{in_stock: true}, {backordered: true}],
   _not: {store_id: 1}           # negate a condition
+  _raw: [
+    {
+      nested: {
+        path: 'dates',
+        query: {
+          bool: {
+            must: [
+              {
+                range: {
+                  'dates.start_at' => {
+                    gte: '2019-07-01',
+                    format: 'yyyy-MM-dd'
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
 }
 ```
 

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -874,6 +874,8 @@ module Searchkick
           filters << {bool: {must_not: where_filters(value)}}
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
+        elsif field == :_raw
+          value.each { |raw_filter| filters << raw_filter }
         # elsif field == :_script
         #   filters << {script: {script: {source: value, lang: "painless"}}}
         else


### PR DESCRIPTION
Hi @ankane. 
It would be nice to have possibility to modify filter with raw elasticsearch query. With it we can solve some rare cases when Searchkick DSL can't satisfy our needs. It also will prevent us from building whole query body from scratch. Refering to issue #1292 it can be solwed with simple part of query

```
raw_filters = 
  [
    {
      nested: {
        path: 'dates',
        query: {
          bool: {
            must: [
              {
                range: {
                  'dates.start_at' => {
                    lte: '2019-07-01',
                    format: 'yyyy-MM-dd'
                  }
                }
              },
              {
                range: {
                  'dates.finish_at' => {
                    gte: '2019-07-01',
                    format: 'yyyy-MM-dd'
                  }
                }
              }            
            ]
          }
        }
      }
    }
  ]

Product.search('*', where: { warehouse_ids: [1], _raw: raw_filters})
```