### PR TITLE
Partial matches below theshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ To change this, use:
 Product.search "fresh honey", operator: "or" # fresh OR honey
 ```
 
+Or if you prefer, Searchkick can first perform a search where results match all the words, and if there are too few results, perform another with partial matches enabled.
+
+```ruby
+Product.search "fresh honey", operator: {below: 5}
+```
+
+If there are fewer than 5 results, a 2nd search is performed with the `or` operator. The result of this query is returned.
+
+
 By default, results must match the entire word - `back` will not match `backpack`. You can change this behavior with:
 
 ```ruby
@@ -386,6 +395,15 @@ Product.search "zuchini", misspellings: {below: 5}
 ```
 
 If there are fewer than 5 results, a 2nd search is performed with misspellings enabled. The result of this query is returned.
+
+You can also combine this behavior with partial matches enabled:
+
+```ruby
+Product.search "zuchini flower", misspellings: {below: 5}, operator: {below: 10}
+```
+
+If there are fewer than 5 results, a 2nd search is performed with misspellings enabled, and if there are fewer than 10 results a 3rd search is performed with partial matches (`or` operator) enabled. The result of this query is returned.
+
 
 Turn off misspellings with:
 

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -221,6 +221,10 @@ module Searchkick
       @options[:misspellings]
     end
 
+    def operator_below?
+      @options[:operator_below]
+    end
+
     def scroll_id
       @response["_scroll_id"]
     end

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -25,6 +25,86 @@ class MatchTest < Minitest::Test
     assert_search "fresh honey", ["fresh", "honey"], {operator: :or}
   end
 
+  def test_operator_below_unmet
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fresh honey", ["fresh honey", "fresh", "honey"], { operator: { below: 2 } }
+  end
+
+  def test_operator_below_unmet_result
+    store_names ["fresh", "honey", "fresh honey"]
+    assert Product.search("fresh honey", operator: {below: 2} ).operator_below?
+  end
+
+  def test_operator_below_met
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fresh honey", ["fresh honey"], { operator: {below: 1} }
+  end
+
+  def test_operator_below_met_result
+    store_names ["fresh", "honey", "fresh honey"]
+    assert !Product.search("fresh honey", operator: {below: 1}).operator_below?
+  end
+
+  def test_operator_below_misspellings_false
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fresh honey", ["fresh", "honey", "fresh honey"], { misspellings: false, operator: {below: 2} }
+  end
+
+  def test_operator_below_misspellings_false_result
+    store_names ["fresh", "honey", "fresh honey"]
+    search = Product.search("fresh honey", misspellings: false, operator: {below: 2} )
+    assert search.operator_below?
+    assert !search.misspellings?
+  end
+
+  def test_operator_below_with_misspellings_without_operator
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fesh honey", ["fresh honey"], { misspellings: {below: 1}, operator: {below: 1} }
+  end
+
+  def test_operator_below_with_misspellings_without_operator_result
+    store_names ["fresh", "honey", "fresh honey"]
+    search = Product.search("fesh honey", misspellings: {below: 1}, operator: {below: 1})
+    assert search.misspellings?
+    assert !search.operator_below?
+  end
+
+  def test_operator_below_with_misspellings_on_operator_retry
+    store_names ["fresh", "honey"]
+    assert_search "fesh honey", ["fresh", "honey"], { misspellings: {below: 1}, operator: {below: 1} }
+  end
+
+  def test_operator_below_with_misspellings_on_operator_retry_result
+    store_names ["fresh", "honey"]
+    search = Product.search("fesh honey", misspellings: {below: 1}, operator: {below: 1})
+    assert search.misspellings?
+    assert search.operator_below?
+  end
+
+  def test_operator_below_with_misspellings_and_operator
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fesh honey", ["fresh", "honey", "fresh honey"], { misspellings: {below: 2}, operator: {below: 2} }
+  end
+
+  def test_operator_below_with_misspellings_and_operator_result
+    store_names ["fresh", "honey", "fresh honey"]
+    search = Product.search("fesh honey", misspellings: {below: 2}, operator: {below: 2})
+    assert search.misspellings?
+    assert search.operator_below?
+  end
+
+  def test_operator_below_with_misspellings_and_operator_bigger_threshold
+    store_names ["fresh", "honey", "fresh honey"]
+    assert_search "fesh honey", ["fresh", "honey", "fresh honey"], { misspellings: {below: 1}, operator: {below: 2} }
+  end
+
+  def test_operator_below_with_misspellings_and_operator_bigger_threshold_result
+    store_names ["fresh", "honey", "fresh honey"]
+    search = Product.search("fesh honey", misspellings: {below: 1}, operator: {below: 2})
+    assert search.misspellings?
+    assert search.operator_below?
+  end
+
   # def test_cheese_space_in_query
   #   store_names ["Pepperjack Cheese Skewers"]
   #   assert_search "pepper jack cheese skewers", ["Pepperjack Cheese Skewers"]


### PR DESCRIPTION
Idea discussed #1283 

I had to make a few more changes than I was expecting initially due to the behavior when we have both `misspellings: { below: X }`  and `operator: { below: X }` - when we execute one, both, in which order, etc. The tests I added should help understand some of the cases I had to work around.

Like you mentioned in #1283 the misspellings retry gets precedence over the operator retry. I added a `retry_order` that at this moment is hard coded, but I can see someone wanting to change this order in the near future, hence I tried making this PR ready for that.

Hope it fits what we discussed, feel free to code review and suggest changes. 