### PR TITLE
Buld reindexing with custom batches

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -169,20 +169,18 @@ module Searchkick
   end
 
   def self.reindex_status(index_name)
-    raise Searchkick::Error, 'Redis not configured' unless redis
-
-    Searchkick::Index.new(index_name).bulk_indexer.status
+    Searchkick::Index.new(index_name).reindex_status
   end
 
   def self.with_redis
-    if redis
-      if redis.respond_to?(:with)
-        redis.with do |r|
-          yield r
-        end
-      else
-        yield redis
+    raise Searchkick::Error, 'Redis not configured' unless redis
+
+    if redis.respond_to?(:with)
+      redis.with do |r|
+        yield r
       end
+    else
+      yield redis
     end
   end
 

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -169,15 +169,9 @@ module Searchkick
   end
 
   def self.reindex_status(index_name)
-    if redis
-      batches_left = Searchkick::Index.new(index_name).batches_left
-      {
-        completed: batches_left == 0,
-        batches_left: batches_left
-      }
-    else
-      raise Searchkick::Error, "Redis not configured"
-    end
+    raise Searchkick::Error, 'Redis not configured' unless redis
+
+    Searchkick::Index.new(index_name).bulk_indexer.status
   end
 
   def self.with_redis

--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -55,6 +55,13 @@ module Searchkick
       Searchkick.with_redis { |r| r.scard(batches_key) }
     end
 
+    def status
+      {
+        completed: batches_left == 0,
+        batches_left: batches_left
+      }
+    end
+
     private
 
     def import_or_update(records, method_name, async)

--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -62,6 +62,16 @@ module Searchkick
       }
     end
 
+    def wait_for_completion
+      loop do
+        sleep 3
+        current_status = status
+        break if current_status[:completed]
+
+        yield current_status if block_given?
+      end
+    end
+
     private
 
     def import_or_update(records, method_name, async)

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -309,7 +309,7 @@ module Searchkick
           puts "Jobs queued. Waiting..."
           loop do
             sleep 3
-            status = Searchkick.reindex_status(index.name)
+            status = bulk_indexer.status
             break if status[:completed]
             puts "Batches left: #{status[:batches_left]}"
           end

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -249,6 +249,10 @@ module Searchkick
       end
     end
 
+    def reindex_status
+      bulk_indexer.status
+    end
+
     protected
 
     def client
@@ -307,10 +311,7 @@ module Searchkick
         if async.is_a?(Hash) && async[:wait]
           puts "Created index: #{index.name}"
           puts "Jobs queued. Waiting..."
-          loop do
-            sleep 3
-            status = bulk_indexer.status
-            break if status[:completed]
+          bulk_indexer.wait_for_completion do |status|
             puts "Batches left: #{status[:batches_left]}"
           end
           # already promoted if alias didn't exist


### PR DESCRIPTION
Hi,

I need to change the batching logic of the bulk indexer (custom sorting with priorities)

I am looking todo something like this:

```
  def self.bulk_reindex(index_name = nil)
    bulk_indexer = Searchkick::BulkIndexer.new(SearchKick::Index.new(index_name))

    loop_by_ids do |ids|
      indexer.bulk_reindex_job(Product, SecureRandom.base64, record_ids: ids)
      Rails.logger.info "Indexing: #{Product.where(id: ids.last).pluck(:created_at).first} #{batch_id}"
    end
    indexer.wait_for_completion do |status|
      Rails.logger.info "Batches left: #{status[:batches_left]}"
    end
  end
```

I did the following change after reading the code (moving some responsabilities).

Tests are passing.

Do you think it is a good idea ? How can I improve it ?