### PR TITLE
Fix `Result window is too large error` w/ Kaminari

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -150,7 +150,7 @@ module Searchkick
     end
 
     def total_pages
-      (total_count / per_page.to_f).ceil
+      ([total_count, 10_000].min / per_page.to_f).ceil
     end
     alias_method :num_pages, :total_pages
 


### PR DESCRIPTION
When using `kaminari` to paginate and displaying results have over 10,000
matches and clicking the `Last` page button, there was the following
`Result window is too large, from + size must be less than or equal to:
[10000] but was [33100]` error.

```
500]
{"error":{"root_cause":[{"type":"query_phase_execution_exception","reason":"Result
window is too large, from + size must be less than or equal to: [10000]
but was [33100]. See the scroll api for a more efficient way to request
large data sets. This limit can be set by changing the
[index.max_result_window] index level
setting."},{"type":"query_phase_execution_exception","reason":"Result
window is too large, from + size must be less than or equal to: [10000]
but was [33100]. See the scroll api for a more efficient way to request
large data sets. This limit can be set by changing the
[index.max_result_window] index level
setting."}],"type":"search_phase_execution_exception","reason":"all
shards
failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"sched_walks_development_20191112105015241","node":"6B4IW3O6Sz-IqfuQa2ZDjQ","reason":{"type":"query_phase_execution_exception","reason":"Result
window is too large, from + size must be less than or equal to: [10000]
but was [33100]. See the scroll api for a more efficient way to request
large data sets. This limit can be set by changing the
[index.max_result_window] index level
setting."}},{"shard":0,"index":"walk_availabilities_development_20191112144735873","node":"6B4IW3O6Sz-IqfuQa2ZDjQ","reason":{"type":"query_phase_execution_exception","reason":"Result
window is too large, from + size must be less than or equal to: [10000]
but was [33100]. See the scroll api for a more efficient way to request
large data sets. This limit can be set by changing the
[index.max_result_window] index level setting."}}]},"status":500}
```

In this example, that produced this error the `per_page` was 50, the `total_count` was 33099,
and the  `total_page` was 662.

The root of the issue is that the `total_page` number which is
currently below doesn't account for the max amount of "pageable" pages.

Another solution would be to increase allow for deep paging (like the new master branch) but that has performance implications I want to avoid.

Please let me know if there is another preferred way to fix this problem. But this worked for me. It limits the `last` page to be the `last` pageable page. 