### PR TITLE
Allow Custom Load Option to be Set in Model

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -7,7 +7,7 @@ module Searchkick
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :language,
         :locations, :mappings, :match, :merge_mappings, :routing, :searchable, :settings, :similarity,
         :special_characters, :stem, :stem_conversions, :suggest, :synonyms, :text_end,
-        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start]
+        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start, :load]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       raise "Only call searchkick once per model" if respond_to?(:searchkick_index)

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -240,7 +240,8 @@ module Searchkick
       scroll = options[:scroll]
 
       # model and eager loading
-      load = options[:load].nil? ? true : options[:load]
+      default_load = searchkick_options[:load].nil? ? true : searchkick_options[:load]
+      load = options[:load].nil? ? default_load : options[:load]
 
       all = term == "*"
 


### PR DESCRIPTION
### Description

At some point, ES have all the data we want and we don't have needs to query from DB again. But I don't want to explicitly set the `load: false` options everytime when we search. I wonder if this is a good place to put the custom option into 😌