### PR TITLE
Fix argument error when passing `refresh` option to `reindex`

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -184,6 +184,7 @@ module Searchkick
 
     def reindex(relation, method_name, scoped:, full: false, scope: nil, **options)
       refresh = options.fetch(:refresh, !scoped)
+      options.delete(:refresh)
 
       if method_name
         # update

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -88,4 +88,8 @@ class ReindexTest < Minitest::Test
   def test_resume
     assert Product.reindex(resume: true)
   end
+
+  def test_full_reindex
+    Product.reindex(refresh: true)
+  end
 end


### PR DESCRIPTION
`reindex_scope` function that is called in the else block of `reindex` raises an argument error exception when `refresh` option is passed on. This commit makes sure it is removed from the options.