### PR TITLE
Boundary character options in highlighting 

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -767,6 +767,11 @@ module Searchkick
         if (fragment_size = options[:highlight][:fragment_size])
           payload[:highlight][:fragment_size] = fragment_size
         end
+
+        if (boundary_chars = options[:highlight][:boundary_chars])
+          payload[:highlight][:boundary_chars] = boundary_chars
+        end
+
         if (encoder = options[:highlight][:encoder])
           payload[:highlight][:encoder] = encoder
         end

--- a/test/highlight_test.rb
+++ b/test/highlight_test.rb
@@ -92,6 +92,13 @@ class HighlightTest < Minitest::Test
     end
   end
 
+  def test_boundary_chars_highlights
+    store_names ["Two <strong>Door Cinema Club Some Other Words And Much More Doors Cinema</strong>Club"]
+    highlight = Product.search("cinema", highlight: {boundary_chars: '/<strong>'}).first.search_highlights[:name]
+    
+    assert_equal "<strong>Door <em>Cinema</em> Club Some Other Words And Much More Doors <em>Cinema</em></strong>", highlight
+  end
+
   def test_search_highlights_method
     store_names ["Two Door Cinema Club"]
     assert_equal "Two Door <em>Cinema</em> Club", Product.search("cinema", highlight: true).first.search_highlights[:name]


### PR DESCRIPTION
If content has html tags, highlighting usually break the format because of default [boundary chars](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#highlighting-settings) options`.,!? \t\n.`.

Example: 
```
  store_names ["Two <strong>Door Cinema Club Some Other Words And Much More Doors Cinema</strong>Club"]

    Product.search("cinema", highlight: true).first.search_highlights[:name]
   => 
<strong>Door <em>Cinema</em> Club Some Other
```

Note: no closing `</strong>` tag in highlight result. And this will break whole document sometime. 

