### PR TITLE
Fix ActiveJob mixed positional & keyword arguments

### DIFF
--- a/lib/searchkick/record_indexer.rb
+++ b/lib/searchkick/record_indexer.rb
@@ -42,9 +42,9 @@ module Searchkick
         end
 
         Searchkick::ReindexV2Job.perform_later(
-          record.class.name,
-          record.id.to_s,
-          method_name ? method_name.to_s : nil,
+          klass: record.class.name,
+          id: record.id.to_s,
+          method_name: method_name ? method_name.to_s : nil,
           routing: routing
         )
       else # bulk, inline/true/nil

--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -9,7 +9,10 @@ module Searchkick
 
     queue_as { Searchkick.queue_name }
 
-    def perform(klass, id, method_name = nil, routing: nil)
+    def perform(args)
+      args = args.first if args.is_a?(Array)
+      klass, id, method_name, routing = args.with_indifferent_access.values_at(:klass, :id, :method_name, :routing)
+
       model = klass.constantize
       record =
         begin


### PR DESCRIPTION
There's an issue with ActiveJob serialization of arguments when you mix positional with keyword arguments:
https://github.com/rails/rails/issues/18741

I had just upgraded my Rails (`4.1.6` -> `5.1.7`) and Searchkick (`1.3.3` -> `4.3.0`) and I faced this issue.

I figured it's better not to mix the argument types but keep the clarity of keyword arguments.

Before fix:
```
12:33:40 reindex.1 | I, [2020-05-10T12:33:40.321777 #28899]  INFO -- : Work job ActiveJob::QueueAdapters::BackburnerAdapter::JobWrapper with [{"job_class"=>"Searchkick::ReindexV2Job", "job_id"=>"219422bd-ac82-45cc-b7e2-5f65ba0c20db", "queue_name"=>"searchkick", "arguments"=>["Redacted", "21125", nil, {"routing"=>nil}]}]
12:33:40 reindex.1 | E, [2020-05-10T12:33:40.324935 #28899] ERROR -- : Exception ArgumentError -> wrong number of arguments (given 4, expected 2..3)
12:33:40 reindex.1 |    /home/araishikeiwai/redacted/shared/bundle/ruby/2.6.0/gems/searchkick-4.3.0/lib/searchkick/reindex_v2_job.rb:12:in `perform'
```

After fix:
```
13:24:31 reindex.1 | I, [2020-05-10T13:24:31.620301 #3155]  INFO -- : Work job ActiveJob::QueueAdapters::BackburnerAdapter::JobWrapper with [{"job_class"=>"Searchkick::ReindexV2Job", "job_id"=>"11c2f491-5356-4209-aae0-27cb36380ca7", "queue_name"=>"searchkick", "arguments"=>[{"klass"=>"Redacted", "id"=>"21125", "method_name"=>nil, "routing"=>nil}]}]
13:24:31 reindex.1 | I, [2020-05-10T13:24:31.988583 #3155]  INFO -- : Completed ActiveJob::QueueAdapters::BackburnerAdapter::JobWrapper in 366ms```

