### PR TITLE
Skip optional regex operators when using `:like` syntax

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -967,7 +967,7 @@ module Searchkick
                   regex.gsub!(v, "\\" + v)
                 end
                 regex = regex.gsub(/(?<!\\)%/, ".*").gsub(/(?<!\\)_/, ".").gsub("\\%", "%").gsub("\\_", "_")
-                filters << {regexp: {field => {value: regex}}}
+                filters << {regexp: {field => {value: regex, flags: "NONE"}}}
               when :prefix
                 filters << {prefix: {field => {value: op_value}}}
               when :regexp # support for regexp queries without using a regexp ruby object

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -166,6 +166,13 @@ class WhereTest < Minitest::Test
     assert_search "product", ["Product ABC\""], where: {name: {like: "%ABC\""}}
   end
 
+  def test_like_optional_operators
+    store_names ["Product A&B", "Product B", "Product <3", "Product @Home"]
+    assert_search "product", ["Product A&B"], where: {name: {like: "%A&B"}}
+    assert_search "product", ["Product <3"], where: {name: {like: "%<%"}}
+    assert_search "product", ["Product @Home"], where: {name: {like: "%@Home%"}}
+  end
+
   # def test_script
   #   store [
   #     {name: "Product A", store_id: 1},


### PR DESCRIPTION
Similar to the fix in 6664a9ea3fc8bf70210937bfd619666672bde220, this
also sets the optional Lucene regex flags to "NONE" when using :like
syntax for searching. Otherwise, searches for strings including any of
the optional operators (# @ & < > ~) causes issues since they are not
escaped.
