### PR TITLE
[1353] Refresh mode option try 2

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -162,6 +162,20 @@ module Searchkick
     end
   end
 
+  def self.wait_for_refresh(value = true)
+    if block_given?
+      previous_value = should_wait_for_refresh
+      begin
+        self.should_wait_for_refresh = value
+        yield
+      ensure
+        self.should_wait_for_refresh = previous_value
+      end
+    else
+      self.should_wait_for_refresh = value
+    end
+  end
+
   def self.aws_credentials=(creds)
     begin
       # TODO remove in Searchkick 5 (just use aws_sigv4)
@@ -234,6 +248,15 @@ module Searchkick
   # private
   def self.callbacks_value=(value)
     Thread.current[:searchkick_callbacks_enabled] = value
+  end
+
+  # private
+  def self.should_wait_for_refresh
+    Thread.current[:searchkick_should_wait_for_refresh]
+  end
+
+  def self.should_wait_for_refresh=(value)
+    Thread.current[:searchkick_should_wait_for_refresh] = value
   end
 
   # private

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -15,7 +15,10 @@ module Searchkick
       items = @queued_items
       @queued_items = []
       if items.any?
-        response = Searchkick.client.bulk(body: items)
+        bulk_index_options = { body: items }
+        bulk_index_options[:refresh] = "wait_for" if Searchkick.should_wait_for_refresh
+
+        response = Searchkick.client.bulk(**bulk_index_options)
         if response["errors"]
           first_with_error = response["items"].map do |item|
             (item["index"] || item["delete"] || item["update"])


### PR DESCRIPTION
See discussion in #1380, in reference to #1353 

I wasn't sure what you meant by "this should be a new reindex mode rather than a global option", so I implemented a handler similar to how you handle callbacks option. If this is not what you meant, could you provide a snippet of the syntax you would find acceptable.

Edit: TODO - lib/chewy/type/import/bulk_request.rb:38