### PR TITLE
Drop redundant LEFT OUTER JOIN constraint for MIN/MAX queries

### DIFF
--- a/lib/searchkick/bulk_indexer.rb
+++ b/lib/searchkick/bulk_indexer.rb
@@ -84,6 +84,9 @@ module Searchkick
 
     def full_reindex_async(scope)
       if scope.respond_to?(:primary_key)
+        # hack to improve performance for MIN, MAX queries as LEFT OUTER JOIN by includes impacts request performance
+        scope = scope.dup.tap {|rel| rel.includes_values = []} if scope.respond_to?(:includes_values=)
+
         # TODO expire Redis key
         primary_key = scope.primary_key
 


### PR DESCRIPTION
Having a lot of relations in includes definition for eager loading (e.g. `includes(:images, :store)`) makes ActiveRecord query for `MIN` and `MAX` much slower as these requests are done with redundant `LEFT OUTER JOIN` constraints.

For the task of `Searchkick::BulkIndexer#full_reindex_async` method those included relations can be securely dropped.

Simplified example of AR behavior for `MIN` query with `includes`: 
```
[1] pry(main)> Product.minimum(:id)
   (0.4ms)  SELECT MIN("products"."id") FROM "products"
=> 1
[2] pry(main)> Product.includes(:company).minimum(:id)
   (0.8ms)  SELECT MIN("products"."id") FROM "products" LEFT OUTER JOIN "companies" ON "companies"."id" = "products"."company_id"
=> 1
```
In real world `search_import` scope can hold a lot of relations for eager loading and simple `MIN/MAX` queries can become slow

[Relevant PR to Rails](https://github.com/rails/rails/pull/40466)