### PR TITLE
Multiple clients

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -40,9 +40,13 @@ module Searchkick
   class ImportError < Error; end
 
   class << self
+    extend Forwardable
+
     attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options
     attr_writer :client, :env, :search_timeout
     attr_reader :aws_credentials
+
+    def_delegators :client, :server_version, :server_below?
   end
   self.search_method_name = :search
   self.wordnet_path = "/var/lib/wn_s.pl"
@@ -62,22 +66,6 @@ module Searchkick
 
   def self.search_timeout
     (defined?(@search_timeout) && @search_timeout) || timeout
-  end
-
-  def self.server_version
-    @server_version ||= client.info["version"]["number"]
-  end
-
-  def self.server_below?(version)
-    Gem::Version.new(server_version.split("-")[0]) < Gem::Version.new(version.split("-")[0])
-  end
-
-  # memoize for performance
-  def self.server_below7?
-    unless defined?(@server_below7)
-      @server_below7 = server_below?("7.0.0")
-    end
-    @server_below7
   end
 
   def self.search(term = "*", model: nil, **options, &block)

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -163,10 +163,10 @@ module Searchkick
     @clients = nil # reset clients
   end
 
-  def self.reindex_status(index_name)
+  def self.reindex_status(*args)
     raise Searchkick::Error, "Redis not configured" unless redis
 
-    batches_left = Searchkick::Index.new(index_name).batches_left
+    batches_left = Searchkick::Index.new(*args).batches_left
     {
       completed: batches_left == 0,
       batches_left: batches_left

--- a/lib/searchkick/client.rb
+++ b/lib/searchkick/client.rb
@@ -21,6 +21,10 @@ module Searchkick
       end
     end
 
+    def host
+      @host ||= @client.transport.hosts.first
+    end
+
     private
 
     def signer_middleware_key

--- a/lib/searchkick/client.rb
+++ b/lib/searchkick/client.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Searchkick
+  class Client
+    attr_reader :aws_credentials
+
+    def initialize(url:, timeout: nil, aws_credentials: nil, **options)
+      @aws_credentials = aws_credentials
+
+      if defined?(Typhoeus) && Gem::Version.new(Faraday::VERSION) < Gem::Version.new('0.14.0')
+        require 'typhoeus/adapters/faraday'
+      end
+
+      @client = Elasticsearch::Client.new({
+        url: url,
+        transport_options: { request: { timeout: timeout }, headers: { content_type: 'application/json' } },
+        retry_on_failure: 2
+      }.deep_merge(options)) do |f|
+        f.use Searchkick::Middleware
+        f.request signer_middleware_key, signer_middleware_aws_params if aws_credentials
+      end
+    end
+
+    private
+
+    def signer_middleware_key
+      defined?(FaradayMiddleware::AwsSignersV4) ? :aws_signers_v4 : :aws_sigv4
+    end
+
+    def signer_middleware_aws_params
+      if signer_middleware_key == :aws_sigv4
+        { service: 'es', region: 'us-east-1' }.merge(aws_credentials)
+      else
+        {
+          credentials: aws_credentials[:credentials] || Aws::Credentials.new(aws_credentials[:access_key_id], aws_credentials[:secret_access_key]),
+          service_name: 'es',
+          region: aws_credentials[:region] || 'us-east-1'
+        }
+      end
+    end
+
+    def method_missing(method_name, *args, &block)
+      @client.send(method_name, *args, &block)
+    end
+
+    def respond_to_missing?(method_name, *_args)
+      @client.respond_to?(method_name)
+    end
+  end
+end

--- a/lib/searchkick/client.rb
+++ b/lib/searchkick/client.rb
@@ -25,6 +25,15 @@ module Searchkick
       @host ||= @client.transport.hosts.first
     end
 
+    def server_version
+      @server_version ||= Gem::Version.new(@client.info["version"]["number"].split("-")[0])
+    end
+
+    def server_below?(version)
+      @server_below ||= {}
+      @server_below[version] ||= server_version < Gem::Version.new(version.split("-")[0])
+    end
+
     private
 
     def signer_middleware_key

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -120,7 +120,7 @@ module Searchkick
     def clean_indices
       indices = all_indices(unaliased: true)
       indices.each do |index|
-        Searchkick::Index.new(index).delete
+        Searchkick::Index.new(index, @options).delete
       end
       indices
     end
@@ -274,8 +274,12 @@ module Searchkick
       index_settings["uuid"]
     end
 
+    def client_name
+      options[:client_name]
+    end
+
     def client
-      Searchkick.client
+      Searchkick.client(client_name)
     end
 
     protected
@@ -341,7 +345,7 @@ module Searchkick
           puts "Jobs queued. Waiting..."
           loop do
             sleep 3
-            status = Searchkick.reindex_status(index.name)
+            status = Searchkick.reindex_status(index.name, options)
             break if status[:completed]
             puts "Batches left: #{status[:batches_left]}"
           end

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -178,7 +178,7 @@ module Searchkick
 
     def reload_synonyms
       require "elasticsearch/xpack"
-      raise Error, "Requires Elasticsearch 7.3+" if Searchkick.server_below?("7.3.0")
+      raise Error, "Requires Elasticsearch 7.3+" if client.server_below?("7.3.0")
       raise Error, "Requires elasticsearch-xpack 7.8+" unless client.xpack.respond_to?(:indices)
       begin
         client.xpack.indices.reload_search_analyzers(index: name)
@@ -274,11 +274,11 @@ module Searchkick
       index_settings["uuid"]
     end
 
-    protected
-
     def client
       Searchkick.client
     end
+
+    protected
 
     def bulk_indexer
       @bulk_indexer ||= BulkIndexer.new(self)

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -7,7 +7,7 @@ module Searchkick
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :language,
         :locations, :mappings, :match, :merge_mappings, :routing, :searchable, :search_synonyms, :settings, :similarity,
         :special_characters, :stem, :stem_conversions, :stem_exclusion, :stemmer_override, :suggest, :synonyms, :text_end,
-        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start]
+        :text_middle, :text_start, :word, :wordnet, :word_end, :word_middle, :word_start, :client_name]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       raise "Only call searchkick once per model" if respond_to?(:searchkick_index)

--- a/lib/searchkick/multi_search.rb
+++ b/lib/searchkick/multi_search.rb
@@ -1,9 +1,10 @@
 module Searchkick
   class MultiSearch
-    attr_reader :queries
+    attr_reader :queries, :client
 
-    def initialize(queries)
+    def initialize(queries, client_name: nil)
       @queries = queries
+      @client = Searchkick.client(client_name)
     end
 
     def perform
@@ -32,10 +33,6 @@ module Searchkick
       end
 
       search_queries
-    end
-
-    def client
-      Searchkick.client
     end
   end
 end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -30,8 +30,8 @@ module Searchkick
         term = EmojiParser.parse_unicode(term) { |e| " #{e.name} " }.strip
       end
 
-      @client = Searchkick.client # temp
       @klass = klass
+      @client = (searchkick_index || Searchkick).client
       @term = term
       @options = options
       @match_suffix = options[:match] || searchkick_options[:match] || "analyzed"
@@ -227,7 +227,7 @@ module Searchkick
     end
 
     def execute_search
-      Searchkick.client.search(params)
+      @client.search(params)
     end
 
     def prepare

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -14,6 +14,8 @@ module Searchkick
       :offset_value, :offset, :previous_page, :prev_page, :next_page, :first_page?, :last_page?,
       :out_of_range?, :hits, :response, :to_a, :first, :scroll
 
+    def_delegators :@client, :host
+
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost,
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :execute, :explain,
@@ -28,6 +30,7 @@ module Searchkick
         term = EmojiParser.parse_unicode(term) { |e| " #{e.name} " }.strip
       end
 
+      @client = Searchkick.client # temp
       @klass = klass
       @term = term
       @options = options
@@ -109,7 +112,6 @@ module Searchkick
       request_params = query.except(:index, :type, :body)
 
       # no easy way to tell which host the client will use
-      host = Searchkick.client.transport.hosts.first
       credentials = host[:user] || host[:password] ? "#{host[:user]}:#{host[:password]}@" : nil
       params = ["pretty"]
       request_params.each do |k, v|

--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -39,7 +39,7 @@ module Searchkick
         _index: index.name,
         _id: search_id
       }
-      data[:_type] = document_type if Searchkick.server_below7?
+      data[:_type] = document_type if index.client.server_below?("7.0.0")
       data[:routing] = record.search_routing if record.respond_to?(:search_routing)
       data
     end

--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -12,17 +12,17 @@ module Searchkick
     def index_data
       data = record_data
       data[:data] = search_data
-      {index: data}
+      {index: data, client_name: index.client_name}
     end
 
     def update_data(method_name)
       data = record_data
       data[:data] = {doc: search_data(method_name)}
-      {update: data}
+      {update: data, client_name: index.client_name}
     end
 
     def delete_data
-      {delete: record_data}
+      {delete: record_data, client_name: index.client_name}
     end
 
     def search_id

--- a/test/clients_test.rb
+++ b/test/clients_test.rb
@@ -1,0 +1,26 @@
+require_relative "test_helper"
+
+class ClientsTest < Minitest::Test
+
+  def setup
+    @default_client_was = Searchkick.client
+  end
+
+  def teardown
+    Searchkick.client = @default_client_was
+  end
+
+  def test_default_client
+    assert_kind_of Searchkick::Client, Searchkick.client
+  end
+
+  def test_setter
+    Searchkick.client = 'foobar'
+    assert_equal 'foobar', Searchkick.client
+  end
+
+  def test_custom_client
+    Searchkick.add_client(:custom, url: 'http://custom:9200')
+    assert_equal 'custom', Searchkick.client(:custom).host.fetch(:host)
+  end
+end


### PR DESCRIPTION
Currently, the Searchkick can work with a single ES cluster only. Having ability to use separate ES clusters per AR model could be helpful for gradual migration between ES clusters.

In order to use custom client:
1. Define client in the initializer
```ruby
Searchkick.add_client :custom_client, url: 'https://user:pass@example.com/'
```

2. Configure model to use custom client
  ```ruby
class MyModel < ApplicationRecord
    searchkick client_name: :custom_client
end
```

Same approach (but different implementation for outdated version of Searchkick) [helped Veeqo to gradually migrate model-by-model between 5.6 and 6.8 ES clusters](https://devs.veeqo.com/a-veeqo-journey-to-become-a-better-elasticsearch-user/).

It is a draft PR. Not sure if the feature is desired for upstream. Should I proceed polishing it and adding more tests and docs?
