### PR TITLE
Emoji matching without misspelling correction

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -25,7 +25,7 @@ module Searchkick
       term = term.to_s
 
       if options[:emoji]
-        term = EmojiParser.parse_unicode(term) { |e| " #{e.name} " }.strip
+        term = EmojiParser.parse_unicode(term) { |e| " #{e.name.tr('_', ' ')} " }.strip
       end
 
       @klass = klass

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -254,6 +254,7 @@ class MatchTest < Minitest::Test
   def test_emoji_multiple
     store_names ["Ice Cream Cake"]
     assert_search "🍨🍰", ["Ice Cream Cake"], emoji: true
+    assert_search "🍨🍰", ["Ice Cream Cake"], emoji: true, misspellings: false
   end
 
   # operator


### PR DESCRIPTION
Splits emoji token names into words and enables emoji support without relying on misspelling correction

Fixes: https://github.com/ankane/searchkick/issues/1469
