### PR TITLE
Add parent_job attr to change inheritance af jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,6 +1880,12 @@ Change search queue name
 Searchkick.queue_name = :search_reindex
 ```
 
+Change the parent job (default to `"ActiveJob::Base"`)
+
+```ruby
+Searchkick.parent_job = "ApplicationJob"
+```
+
 Eager load associations
 
 ```ruby

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -39,7 +39,7 @@ module Searchkick
   class ImportError < Error; end
 
   class << self
-    attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options
+    attr_accessor :search_method_name, :wordnet_path, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options, :parent_job
     attr_writer :client, :env, :search_timeout
     attr_reader :aws_credentials
   end
@@ -50,6 +50,7 @@ module Searchkick
   self.client_options = {}
   self.queue_name = :searchkick
   self.model_options = {}
+  self.parent_job = "ActiveJob::Base"
 
   def self.client
     @client ||= begin

--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -1,5 +1,5 @@
 module Searchkick
-  class BulkReindexJob < ActiveJob::Base
+  class BulkReindexJob < Searchkick.parent_job.constantize
     queue_as { Searchkick.queue_name }
 
     def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)

--- a/lib/searchkick/process_batch_job.rb
+++ b/lib/searchkick/process_batch_job.rb
@@ -1,5 +1,5 @@
 module Searchkick
-  class ProcessBatchJob < ActiveJob::Base
+  class ProcessBatchJob < Searchkick.parent_job.constantize
     queue_as { Searchkick.queue_name }
 
     def perform(class_name:, record_ids:, index_name: nil)

--- a/lib/searchkick/process_queue_job.rb
+++ b/lib/searchkick/process_queue_job.rb
@@ -1,5 +1,5 @@
 module Searchkick
-  class ProcessQueueJob < ActiveJob::Base
+  class ProcessQueueJob < Searchkick.parent_job.constantize
     queue_as { Searchkick.queue_name }
 
     def perform(class_name:, index_name: nil, inline: false)

--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -1,5 +1,5 @@
 module Searchkick
-  class ReindexV2Job < ActiveJob::Base
+  class ReindexV2Job < Searchkick.parent_job.constantize
     RECORD_NOT_FOUND_CLASSES = [
       "ActiveRecord::RecordNotFound",
       "Mongoid::Errors::DocumentNotFound",


### PR DESCRIPTION
Hi,

In order to add some callbacks to Searchkick jobs or use new features from ActiveJob, it could be nice to have a config option to change the default inheritance.

This is also an opportunity to thank you for this awesome gem!
Kevyn

