### PR TITLE
Use `Searchkick::Results` as class for `model_name` when searching across multiple models

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -1,5 +1,5 @@
 require "forwardable"
-require "active_support/core_ext" # Required by active_model/naming
+require "active_support/core_ext/module/delegation" # Required by active_model/naming
 require "active_model/naming"
 
 module Searchkick

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -74,7 +74,7 @@ module Searchkick
 
     def model_name
       if klass.nil?
-        ActiveModel::Name.new(self.class)
+        ActiveModel::Name.new(self.class, nil, 'Result')
       else
         klass.model_name
       end

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -1,4 +1,6 @@
 require "forwardable"
+require "active_support/core_ext" # Required by active_model/naming
+require "active_model/naming"
 
 module Searchkick
   class Results
@@ -71,7 +73,11 @@ module Searchkick
     end
 
     def model_name
-      klass.model_name
+      if klass.nil?
+        ActiveModel::Name.new(self.class)
+      else
+        klass.model_name
+      end
     end
 
     def entry_name(options = {})

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -1,6 +1,4 @@
 require "forwardable"
-require "active_support/core_ext/module/delegation" # Required by active_model/naming
-require "active_model/naming"
 
 module Searchkick
   class Results

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -24,6 +24,6 @@ class ResultsTest < Minitest::Test
   def test_model_name_without_klass
     store_names ["Product A", "Product B"]
     results = Searchkick.search("product")
-    assert_equal "Results", results.model_name.human
+    assert_equal "Result", results.model_name.human
   end
 end

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -14,4 +14,16 @@ class ResultsTest < Minitest::Test
     end
     assert_equal 2, count
   end
+
+  def test_model_name_with_klass
+    store_names ["Product A", "Product B"]
+    results = Product.search("product")
+    assert_equal "Product", results.model_name.human
+  end
+
+  def test_model_name_without_klass
+    store_names ["Product A", "Product B"]
+    results = Searchkick.search("product")
+    assert_equal "Results", results.model_name.human
+  end
 end


### PR DESCRIPTION
As noted by #1491, `Searchkick::Results.model_name` returns an error if searching across multiple models. This PR adds a conditional to ensure that in this case, `model_name` falls back to just returning an `ActiveModel::Name` on itself. In practice, this means that `results.model_name.human` will return `Results` instead of an error.

One thing I wasn't totally sure about was whether to keep the model name as plural ("Results") or singularize it to ("Result"). Ultimately, since the class is named "Results" I decided to stay with the plural but note that this does slightly differ from the singe model search case which would return "Product". I don't care too strongly either way though and am happy to change it – I'm mainly interested in this method because it's used internally by Kaminari, but Kaminari's pretty good about calling singularize/pluralize on the model name depending on the number of results so the model name's pluralization doesn't matter in this case.
