### PR TITLE
Add support for different table/structure inherited models

### DIFF
--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -99,6 +99,21 @@ class InheritanceTest < Minitest::Test
     assert_equal expected, Searchkick.search("bear", models: [Cat, Product], per_page: 1).total_pages
   end
 
+  def test_inherited_model_custom_table_name
+    skip unless activerecord?
+
+    store_names ["Knot A"], Thing
+    store_names ["Knot B"], Wheel
+    store_names ["Knot C"]
+    Thing.reindex
+
+    assert_equal 2, Searchkick.search("knot", models: [Wheel, Product]).size
+    assert_equal 2, Searchkick.search("knot", models: [Wheel, Thing]).size
+
+    assert_equal 'wheels_test', Wheel.searchkick_index.name
+    assert_equal 'things_test', Thing.searchkick_index.name
+  end
+
   # TODO move somewhere better
 
   def test_multiple_indices

--- a/test/models/thing.rb
+++ b/test/models/thing.rb
@@ -1,0 +1,6 @@
+class Thing
+  searchkick \
+    text_start: [:name],
+    suggest: [:name],
+    callbacks: :async
+end

--- a/test/support/activerecord.rb
+++ b/test/support/activerecord.rb
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define do
     t.string :type
   end
 
+  create_table :things do |t|
+    t.string :name
+    t.string :type
+  end
+
+  create_table :wheels do |t|
+    t.string :name
+    t.string :type
+  end
+
   create_table :skus, id: :uuid do |t|
     t.string :name
   end
@@ -83,6 +93,13 @@ class Dog < Animal
 end
 
 class Cat < Animal
+end
+
+class Thing < ActiveRecord::Base
+end
+
+class Wheel < Thing
+  self.table_name = 'wheels'
 end
 
 class Sku < ActiveRecord::Base

--- a/test/support/mongoid.rb
+++ b/test/support/mongoid.rb
@@ -55,6 +55,15 @@ end
 class Cat < Animal
 end
 
+class Thing
+  include Mongoid::Document
+
+  field :name
+end
+
+class Wheel < Thing
+end
+
 class Sku
   include Mongoid::Document
 

--- a/test/support/nobrainer.rb
+++ b/test/support/nobrainer.rb
@@ -58,6 +58,16 @@ end
 class Cat < Animal
 end
 
+class Thing
+  include NoBrainer::Document
+
+  field :id,   type: Object
+  field :name, type: String
+end
+
+class Wheel < Thing
+end
+
 class Sku
   include NoBrainer::Document
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,8 @@ Product.create!(name: "Set mapping")
 
 Store.reindex
 Animal.reindex
+Thing.reindex
+Wheel.reindex
 Speaker.reindex
 Region.reindex
 
@@ -70,6 +72,8 @@ class Minitest::Test
     Store.destroy_all
     Animal.destroy_all
     Speaker.destroy_all
+    Thing.destroy_all
+    Wheel.destroy_all
   end
 
   protected


### PR DESCRIPTION
Currently inherited models also inherit index name and reindex hooks (with searchkick re-define raising exception), but there's such use cases where inheritance is only code based and model hold different data structure, in which case searchkick simply does not support reindexing that model and fallbacks to it's superclass.

This PR tries to support different table indexes with inherited model code without breaking current inheritance options.
