### PR TITLE
Add support for case-insensitive regex filter

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -1028,10 +1028,6 @@ module Searchkick
       elsif value.nil?
         {bool: {must_not: {exists: {field: field}}}}
       elsif value.is_a?(Regexp)
-        if value.casefold?
-          Searchkick.warn("Case-insensitive flag does not work with Elasticsearch")
-        end
-
         source = value.source
         unless source.start_with?("\\A") && source.end_with?("\\z")
           # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
@@ -1053,7 +1049,7 @@ module Searchkick
           # source = "#{source}.*"
         end
 
-        {regexp: {field => {value: source, flags: "NONE"}}}
+        {regexp: {field => {value: source, flags: "NONE", case_insensitive: value.casefold?}}}
       else
         # TODO add this for other values
         if value.as_json.is_a?(Enumerable)

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -1049,7 +1049,14 @@ module Searchkick
           # source = "#{source}.*"
         end
 
-        {regexp: {field => {value: source, flags: "NONE", case_insensitive: value.casefold?}}}
+        if below710?
+          if value.casefold?
+            Searchkick.warn("Case-insensitive flag does not work with Elasticsearch < 7.10")
+          end
+          {regexp: {field => {value: source, flags: "NONE"}}}
+        else
+          {regexp: {field => {value: source, flags: "NONE", case_insensitive: value.casefold?}}}
+        end
       else
         # TODO add this for other values
         if value.as_json.is_a?(Enumerable)
@@ -1146,6 +1153,10 @@ module Searchkick
 
     def below75?
       Searchkick.server_below?("7.5.0")
+    end
+
+    def below710?
+      Searchkick.server_below?("7.10.0")
     end
   end
 end

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -141,10 +141,8 @@ class WhereTest < Minitest::Test
   def test_regexp_case
     store_names ["abcde"]
     assert_search "*", [], where: {name: /\AABCDE\z/}
-    # flags don't work
-    assert_warns "Case-insensitive flag does not work with Elasticsearch" do
-      assert_search "*", [], where: {name: /\AABCDE\z/i}
-    end
+    assert_search "*", ["abcde"], where: {name: /\AABCDE\z/i}
+    assert_search "*", ["abcde"], where: {name: /\AaBcDe\z/i}
   end
 
   def test_prefix

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -141,8 +141,13 @@ class WhereTest < Minitest::Test
   def test_regexp_case
     store_names ["abcde"]
     assert_search "*", [], where: {name: /\AABCDE\z/}
-    assert_search "*", ["abcde"], where: {name: /\AABCDE\z/i}
-    assert_search "*", ["abcde"], where: {name: /\AaBcDe\z/i}
+    if Searchkick.server_below?("7.10.0")
+      assert_warns "Case-insensitive flag does not work with Elasticsearch < 7.10" do
+        assert_search "*", [], where: {name: /\AABCDE\z/i}
+      end
+    else
+      assert_search "*", ["abcde"], where: {name: /\AABCDE\z/i}
+    end
   end
 
   def test_prefix


### PR DESCRIPTION
fixes https://github.com/ankane/searchkick/issues/1461

This PR will allow the use of case insensitive regexes in query filters.
If the `i` flag is present on the regex, then `case_insensitive` will be set to `true` in the filter, otherwise it will be set to `false`.

#### Examples:

##### With case insensitive regex flag
```rb
3.0.2 :001 > Product.search('*', where: {name: /\Afoo\z/i})
  Product Search (25.3ms)  products_development/_search
{
  "query":{
    "bool":{
      "must":{
        "match_all":{}
      },
      "filter":[
        {
          "regexp":{
            "name":{
              "value":"foo",
              "flags":"NONE",
              "case_insensitive":true
            }
          }
        }
      ]
    }
  },
  "timeout":"16s",
  "_source":false,
  "size":10000
}
```

##### Without case insensitive regex flag
```rb
3.0.2 :002 > Product.kicksearch('*', where: {first_name: /\Afoo\z/})
  Product Search (22.2ms)  products_development/_search
{
  "query":{
    "bool":{
      "must":{
        "match_all":{}
      },
      "filter":[
        {
          "regexp":{
            "name":{
              "value":"foo",
              "flags":"NONE",
              "case_insensitive":false
            }
          }
        }
      ]
    }
  },
  "timeout":"16s",
  "_source":false,
  "size":10000
}
```
