### PR TITLE
Add support for beginless ranges in where queries

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -904,12 +904,7 @@ module Searchkick
         else
           # expand ranges
           if value.is_a?(Range)
-            # infinite? added in Ruby 2.4
-            if value.end.nil? || (value.end.respond_to?(:infinite?) && value.end.infinite?)
-              value = {gte: value.first}
-            else
-              value = {gte: value.first, (value.exclude_end? ? :lt : :lte) => value.last}
-            end
+            value = expand_range(value)
           end
 
           value = {in: value} if value.is_a?(Array)
@@ -1136,6 +1131,17 @@ module Searchkick
       else
         value
       end
+    end
+
+    def expand_range(range)
+      expanded = {}
+      expanded[:gte] = range.begin if range.begin
+
+      if range.end && !(range.end.respond_to?(:infinite?) && range.end.infinite?)
+        expanded[range.exclude_end? ? :lt : :lte] = range.end
+      end
+
+      expanded
     end
 
     def base_field(k)

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -46,6 +46,11 @@ class WhereTest < Minitest::Test
       # use eval to prevent parse error
       assert_search "product", ["Product C", "Product D"], where: {store_id: eval("3..")}
     end
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0")
+      # use eval to prevent parse error
+      assert_search "product", ["Product A", "Product B"], where: {store_id: eval("..2")}
+      assert_search "product", ["Product A", "Product B"], where: {store_id: eval("...3")}
+    end
 
     # or
     assert_search "product", ["Product A", "Product B", "Product C"], where: {or: [[{in_stock: true}, {store_id: 3}]]}


### PR DESCRIPTION
This PR adds support for beginless ranges (`..5`) in the `where` field of the search method.

Closes #1524