### PR TITLE
docs: "complete list of analyzers." use relative file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,7 @@ Product.search_index.tokens("dieg", analyzer: "searchkick_word_search")
 # ["dieg"] - match!!
 ```
 
-See the [complete list of analyzers](https://github.com/ankane/searchkick/blob/31780ddac7a89eab1e0552a32b403f2040a37931/lib/searchkick/index_options.rb#L32).
+See the [complete list of analyzers](lib/searchkick/index_options.rb#L32).
 
 ## Testing
 


### PR DESCRIPTION
The link to the analyzers is a hardcoded link to a previous version of the file. Instead, use a relative link that points to the most recent version. 

I noticed this because all of the language analyzers are in not in the old link. 