### PR TITLE
Ease up Mongoid dependency in Searchkick.relation?

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -329,7 +329,7 @@ module Searchkick
     if klass.respond_to?(:current_scope)
       !klass.current_scope.nil?
     else
-      klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
+      defined?(Mongoid) && (klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?)
     end
   end
 


### PR DESCRIPTION
The method will fail with `NameError` if an app doesn't have `mongoid` in its Gemfile:

```
=> #<NameError: uninitialized constant Searchkick::Mongoid

      klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
                  ^^^^^^^>
```

The problem was encountered in Rails 7.0.2.3 app.

There's also may be a similar problem in `Searchkick::RelationIndexer#in_batches`:

https://github.com/ankane/searchkick/blob/29b48bc274bd41785e8a5206cd9465f83de696ba/lib/searchkick/relation_indexer.rb#L90-L104

but we haven't encountered it yet. Let me know if it should be included. It's not very obvious what can be returned here as a fallback though.