### PR TITLE
Adds bulk_queue_name as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.4 (unreleased)
 
 - Added `max_result_window` option
+- Added `bulk_queue_name` option
 
 ## 5.0.3 (2022-03-13)
 

--- a/README.md
+++ b/README.md
@@ -1957,6 +1957,12 @@ Change search queue name
 Searchkick.queue_name = :search_reindex
 ```
 
+Change queue name for bulk reindexing
+
+```ruby
+Searchkick.bulk_queue_name = :bulk_search_reindex
+```
+
 Eager load associations
 
 ```ruby

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -55,7 +55,7 @@ module Searchkick
   class ImportError < Error; end
 
   class << self
-    attr_accessor :search_method_name, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options, :client_type
+    attr_accessor :search_method_name, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :bulk_queue_name, :model_options, :client_type
     attr_writer :client, :env, :search_timeout
     attr_reader :aws_credentials
   end
@@ -64,6 +64,7 @@ module Searchkick
   self.models = []
   self.client_options = {}
   self.queue_name = :searchkick
+  self.bulk_queue_name = :searchkick
   self.model_options = {}
 
   def self.client

--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -1,6 +1,6 @@
 module Searchkick
   class BulkReindexJob < ActiveJob::Base
-    queue_as { Searchkick.queue_name }
+    queue_as { Searchkick.bulk_queue_name }
 
     # TODO remove min_id and max_id in Searchkick 6
     def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil)


### PR DESCRIPTION
This PR adds a `bulk_queue_name` option for `BulkReindexJob`. This would be helpful as currently when we bulk reindex the `searchkick` queue gets filled up and delays incoming (time sensitive) reindex jobs.

There may already be a better solution for this as I imagine others face the same issue, but I didn't see anything.

Thanks!
