### PR TITLE
Add model name to warning message

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -302,7 +302,7 @@ module Searchkick
     def build_hits
       @build_hits ||= begin
         if missing_records.any?
-          Searchkick.warn("Records in search index do not exist in database: #{missing_records.map { |v| v[:id] }.join(", ")}")
+          Searchkick.warn("#{@klass} records in search index do not exist in database: #{missing_records.map { |v| v[:id] }.join(", ")}")
         end
         with_hit_and_missing_records[0]
       end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -84,7 +84,7 @@ class QueryTest < Minitest::Test
     skip unless activerecord?
 
     store_names ["Product A", "Product B"]
-    assert_warns "Records in search index do not exist in database" do
+    assert_warns "Product records in search index do not exist in database" do
       assert_search "product", ["Product A"], scope_results: ->(r) { r.where(name: "Product A") }
     end
   end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -32,7 +32,7 @@ class SearchTest < Minitest::Test
     store_names ["Product A", "Product B"]
     product = Product.find_by(name: "Product A")
     product.delete
-    assert_output nil, /\[searchkick\] WARNING: Records in search index do not exist in database/ do
+    assert_output nil, /\[searchkick\] WARNING: Product records in search index do not exist in database/ do
       result = Product.search("product")
       assert_equal ["Product B"], result.map(&:name)
       assert_equal [product.id.to_s], result.missing_records.map { |v| v[:id] }


### PR DESCRIPTION
I find `[searchkick] WARNING: Records in search index do not exist in database: 4598, 5450, 6192, 6216, 7018, 7245, 7266` unclear to which model these ids related. For better understanding, I would like to add the model name so that it will look like `[searchkick] WARNING: User records in search index do not exist in the database: 4598, 5450, 6192, 6216, 7018, 7245, 7266`
