### PR TITLE
Allow to skip reindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -2058,10 +2058,11 @@ Reindex conditionally
 
 ```ruby
 class Product < ApplicationRecord
-  searchkick callbacks: false
+  searchkick
 
-  # add the callbacks manually
-  after_commit :reindex, if: -> (model) { model.previous_changes.key?("name") } # use your own condition
+  def skip_searchkick_reindex?
+    persisted? && saved_changes.keys == ['updated_at']
+  end
 end
 ```
 

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -46,6 +46,10 @@ module Searchkick
         def should_index?
           true
         end unless base.method_defined?(:should_index?)
+
+        def skip_searchkick_reindex?
+          false
+        end
       end
 
       class_eval do
@@ -99,10 +103,10 @@ module Searchkick
         # always add callbacks, even when callbacks is false
         # so Model.callbacks block can be used
         if respond_to?(:after_commit)
-          after_commit :reindex, if: -> { Searchkick.callbacks?(default: callbacks) }
+          after_commit :reindex, if: proc { Searchkick.callbacks?(default: callbacks) && !skip_searchkick_reindex? }
         elsif respond_to?(:after_save)
-          after_save :reindex, if: -> { Searchkick.callbacks?(default: callbacks) }
-          after_destroy :reindex, if: -> { Searchkick.callbacks?(default: callbacks) }
+          after_save :reindex, if: proc { Searchkick.callbacks?(default: callbacks) && !skip_searchkick_reindex? }
+          after_destroy :reindex, if: proc { Searchkick.callbacks?(default: callbacks) && !skip_searchkick_reindex? }
         end
       end
     end


### PR DESCRIPTION
`searchkick` triggers reindex on any change, including touch, but some fields (e.g. `updated_at`) may not be stored in index and there's no point in reindexing.

Current docs suggest manually defining callbacks, but that won't work with `Searchkick.callbacks(:bulk) do`, which will always trigger a reindex.

I've added a `skip_searchkick_reindex?` method which users may override to define their own logic.