### PR TITLE
Add support for script filtering with painless

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -904,8 +904,8 @@ module Searchkick
           filters << {bool: {must_not: where_filters(value)}}
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
-        # elsif field == :_script
-        #   filters << {script: {script: {source: value, lang: "painless"}}}
+        elsif field == :_script
+          filters << {bool: {filter: {script: {script: value}}}}
         else
           # expand ranges
           if value.is_a?(Range)

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -905,7 +905,7 @@ module Searchkick
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
         elsif field == :_script
-          filters << {bool: {filter: {script: {script: {source: value, lang: 'painless'}}}}}
+          filters << {bool: {filter: {script: {script: {source: value, lang: "painless"}}}}}
         else
           # expand ranges
           if value.is_a?(Range)

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -905,7 +905,7 @@ module Searchkick
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
         elsif field == :_script
-          filters << {bool: {filter: {script: {script: value}}}}
+          filters << {bool: {filter: {script: {script: {source: value, lang: 'painless'}}}}}
         else
           # expand ranges
           if value.is_a?(Range)

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -254,13 +254,14 @@ class WhereTest < Minitest::Test
     assert_search "product", ["Product @Home"], where: {name: {ilike: "%@home%"}}
   end
 
-  # def test_script
-  #   store [
-  #     {name: "Product A", store_id: 1},
-  #     {name: "Product B", store_id: 10}
-  #   ]
-  #   assert_search "product", ["Product A"], where: {_script: "doc['store_id'].value < 10"}
-  # end
+  def test_script
+    store [
+      {name: "Product A", store_id: 1},
+      {name: "Product B", store_id: 10}
+    ]
+    assert_search "product", ["Product A"], where: {_script: "doc['store_id'].value < 10"}
+    assert_search "product", ["Product B"], where: {_script: "doc['name'].value == 'Product B'"}
+  end
 
   def test_where_string
     store [

--- a/test/where_test.rb
+++ b/test/where_test.rb
@@ -261,6 +261,7 @@ class WhereTest < Minitest::Test
     ]
     assert_search "product", ["Product A"], where: {_script: "doc['store_id'].value < 10"}
     assert_search "product", ["Product B"], where: {_script: "doc['name'].value == 'Product B'"}
+    assert_search "product", ["Product B"], where: {_script: "doc['name'].value.toLowerCase() == 'product b'"}
   end
 
   def test_where_string


### PR DESCRIPTION
This PR enables support for the `_script` filter in Searchkick queries. I would like to add this functionality to support more complex querying cases where the base query language is insufficient.