### PR TITLE
Replace Redis lists usage for Redis sets for reindex queue

### DIFF
--- a/lib/searchkick/reindex_queue.rb
+++ b/lib/searchkick/reindex_queue.rb
@@ -50,14 +50,6 @@ module Searchkick
       "searchkick:reindex_queue:#{name}"
     end
 
-    def supports_rpop_with_count?
-      redis_version >= Gem::Version.new("6.2")
-    end
-
-    def redis_version
-      @redis_version ||= Searchkick.with_redis { |r| Gem::Version.new(r.info["redis_version"]) }
-    end
-
     def escape(value)
       value.gsub("|", "||")
     end

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -54,13 +54,12 @@ class ReindexTest < Minitest::Test
     store_names ["Product A"], reindex: false
 
     product = Product.find_by!(name: "Product A")
-    before_length = reindex_queue.length
+
+    assert_equal 0, reindex_queue.length, "reindex queue should be empty"
     assert_equal true, product.reindex(mode: :queue)
-    after_length = reindex_queue.length
-    assert_equal after_length, before_length + 1, "reindex queue should grow by 1"
+    assert_equal 1, reindex_queue.length, "reindex queue should grow by 1"
     assert_equal true, product.reindex(mode: :queue)
-    duplicate_length = reindex_queue.length
-    assert_equal duplicate_length, after_length, "reindex queue should not grow with duplicate record"
+    assert_equal 1, reindex_queue.length, "reindex queue should not grow with duplicate record"
   end
 
   def test_record_index


### PR DESCRIPTION
This PR updates Searchkick::ReindexQueue to use [Redis sets](https://redis.io/docs/data-types/sets/) instead of lists when keeping track of records that need to be reindexed.

> A Redis set is an unordered collection of unique strings (members). You can use Redis sets to efficiently:
> - **Track unique items (e.g., track all unique IP addresses accessing a given blog post).**
> - Represent relations (e.g., the set of all users with a given role).
> - Perform common set operations such as intersection, unions, and differences.

This change will prevent the reindex queue from ballooning with duplicate records at risk of increasing Redis memory usage and unnecessary duplicate reindexing as it works through the list.

## Background

I observed an application on Heroku using the [Heroku Redis Premium 0](https://elements.heroku.com/addons/heroku-redis) plan running into out of memory errors all of a sudden for the 50 MB allocated to the Redis instance. Upon further investigation using `redis-cli --bigkeys` I found 2 of my reindex queues were taking up 48 MB of the 50 MB.

Inspecting an example range of records needing to be reindexed, only 21 out of the 1,000 records were unique.

```ruby
ids = Stock.redis.lrange("searchkick:reindex_queue:products_production", 0, 999)
ids.uniq.length # => 21
ids.length # => 1000
```

Redis information:

```
> LLEN "searchkick:reindex_queue:products_production"
(integer) 6176148
> INFO
# Memory
used_memory:52028680
used_memory_human:49.62M
> DEL "searchkick:reindex_queue:products_production"
(integer) 1
> INFO
# Memory
used_memory:27195120
used_memory_human:25.94M
> DEL "searchkick:reindex_queue:product_variants_production"
(integer) 1
> INFO
# Memory
used_memory:2424296
used_memory_human:2.31M
```

After the Redis instance ran out of memory, no more jobs could be enqueued. Most notably the `Searchkick::ProcessQueueJob` which would have worked off some of the records queued to be reindexed. For my particular setup, I have the `Searchkick::ProcessQueueJob` job going every 10 minutes (due to Heroku Scheduler having 10 minutes be the lowest interval offered).

## Breaking change

One risk with this change is it would be considered a breaking change as the Redis key would have to be updated to use sets in place of lists to account for existing reindex queues upon a version upgrade.

```
> SPOP "searchkick:reindex_queue:products_production" 999
(error) WRONGTYPE Operation against a key holding the wrong kind of value
```

**Changing the reindex queue Redis key name**
This would avoid any Redis errors, but risks records queued to be reindexed never actually reindexed. Instructing users how to migrate in a major release bump or provide a Rake task could suffice (untested illustrative script):

```ruby
def redis_version
  @redis_version ||= Searchkick.with_redis { |r| Gem::Version.new(r.info["redis_version"]) }
end

def supports_rpop_with_count?
  redis_version >= Gem::Version.new("6.2")
end

def reserve(redis_key, limit:)
  record_ids = if supports_rpop_with_count?
    Searchkick.with_redis { |r| r.call("rpop", redis_key, limit) }.to_a
  else
    record_ids = []
    Searchkick.with_redis do |r|
      while record_ids.size < limit && (record_id = r.rpop(redis_key))
        record_ids << record_id
      end
    end
    record_ids
  end
end

def migrate(model, limit: 1000)
  redis_key = "searchkick:reindex_queue:#{model.search_index.name}"
  
  while (record_ids = reserve(redis_key, limit: limit)).any?
    model.reindex_queue.push(record_ids)
  end

  Searchkick.with_redis do |r|
    r.del(redis_key)
  end
end

Searchkick.models.each do |model|
  migrate(model)
end
```

