### PR TITLE
[relation_indexer] improve support for custom select clause

### DIFF
--- a/lib/searchkick/relation_indexer.rb
+++ b/lib/searchkick/relation_indexer.rb
@@ -17,7 +17,7 @@ module Searchkick
       # remove unneeded loading for async
       if mode == :async
         if relation.respond_to?(:primary_key)
-          relation = relation.select(relation.primary_key).except(:includes, :preload)
+          relation = relation.except(:includes, :preload, :select).select(relation.primary_key)
         elsif relation.respond_to?(:only)
           relation = relation.only(:_id)
         end


### PR DESCRIPTION
### Description
We want to add a custom select clause to a model's `search_import` scope.
This PR improves the SQL queries for asynchronous reindexing.

---
### Example
- The table product  has 100+ attributes in our Postgres DB.
- The corresponding Opensearch index contains only 3 fields.
- We define a custom select clause in the `search_import` scope for efficiency.

```ruby
class Product < ApplicationRecord
  scope :search_import, -> { select(:id, :name, :color) }

  def search_data
    {
      id:    id,
      name:  name,
      color: color
    }
  end
end
```

### Reindex synchronously
Reindexing the records synchronously works as expected:
```ruby
Product.reindex
```

```SQL
-- sample query
SELECT "products"."id", "products"."name", "products"."color"
FROM "products"
ORDER BY "products"."id" ASC
LIMIT 1000
```

### Reindex asynchronously (issue)
To reindex the records asynchronously, searchkick should only select the PK attribute and ignore the custom select clause:
```ruby
Product.reindex(mode: :async)
```

```SQL
-- expected query
SELECT "products"."id"
FROM "products"
ORDER BY "products"."id" ASC
LIMIT 1000

-- actual query
SELECT "products"."id", "products"."name", "products"."color", "products"."id"
FROM "products"
ORDER BY "products"."id" ASC
LIMIT 1000
```
