### PR TITLE
Added arguments to unscoped option

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,16 @@ class Product < ApplicationRecord
 end
 ```
 
+If you would like to only exclude certain default scopes, set:
+```ruby
+class Person
+  searchkick word_start: [:name], unscope: { where: :kind }
+
+  default_scope -> { where(account_id: current_account) }
+  default_scope -> { where.not(kind: 'guest') }
+end
+```
+
 ## Intelligent Search
 
 The best starting point to improve your search **by far** is to track searches and conversions. [Searchjoy](https://github.com/ankane/searchjoy) makes it easy.

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -338,8 +338,10 @@ module Searchkick
     # safety check to make sure used properly in code
     raise Error, "Cannot scope relation" if relation?(model)
 
-    if model.searchkick_options[:unscope]
+    if model.searchkick_options[:unscope] == true
       model.unscoped
+    elsif model.searchkick_options[:unscope].is_a? Hash
+      model.unscope(model.searchkick_options[:unscope])
     else
       model
     end

--- a/test/models/album.rb
+++ b/test/models/album.rb
@@ -1,0 +1,3 @@
+class Album
+  searchkick unscope: { where: [:active, :sold] }
+end

--- a/test/support/activerecord.rb
+++ b/test/support/activerecord.rb
@@ -71,6 +71,12 @@ ActiveRecord::Schema.define do
     t.boolean :active
     t.boolean :should_index
   end
+
+  create_table :albums do |t|
+    t.string :name
+    t.boolean :active
+    t.boolean :sold
+  end
 end
 
 class Product < ActiveRecord::Base
@@ -108,4 +114,8 @@ end
 
 class Artist < ActiveRecord::Base
   default_scope { where(active: true).order(:name) }
+end
+
+class Album < ActiveRecord::Base
+  default_scope { where(active: true).where(sold: true).order(:name) }
 end

--- a/test/unscope_arguments_test.rb
+++ b/test/unscope_arguments_test.rb
@@ -1,0 +1,40 @@
+require_relative "test_helper"
+
+class UnscopeTest < Minitest::Test
+  def setup
+    @@once ||= Album.reindex
+
+    Album.unscoped.destroy_all
+  end
+
+  def test_reindex
+    create_records
+
+    Album.reindex
+    assert_search "*", ["Test", "Test 2", "Test 3"]
+    assert_search "*", ["Test", "Test 2", "Test 3"], {load: false}
+  end
+
+  def test_relation_async
+    create_records
+
+    perform_enqueued_jobs do
+      Album.unscoped.reindex(mode: :async)
+    end
+
+    Album.search_index.refresh
+    assert_search "*", ["Test", "Test 2", "Test 3"]
+  end
+
+  def create_records
+    store [
+      {name: "Test", active: true},
+      {name: "Test 2", active: false},
+      {name: "Test 3", active: false, sold: false},
+    ], reindex: false
+  end
+
+  def default_model
+    Album
+  end
+end


### PR DESCRIPTION
This is a proposition for my specific use case, but I realized that could be useful regardless.
My current use case:
```ruby
class Person
  searchkick word_start: [:name]

  default_scope -> { where(account_id: current_account) }
  default_scope -> { where.not(kind: 'guest') }
  
  scope :guests, -> { rewhere(kind: 'guest') }
end
```

Now, normally I don't need to see guests, but when searching with searchkick, I'd like to see all records.
However if I choose to use 
```ruby
  searchkick word_start: [:name], unscope: true
```
it would also unscope `account_id` and this is a scope I need every time.
Which brings us to this proposition, rather simple, but I feel like it was a missing feature. It's my first time contributing so please let me know if you have any questions.