### PR TITLE
Update Index#total_docs to pull in full record count

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -67,7 +67,8 @@ module Searchkick
           index: name,
           body: {
             query: {match_all: {}},
-            size: 0
+            size: 0,
+            track_total_hits: true
           }
         )
 


### PR DESCRIPTION
Referencing https://github.com/ankane/searchkick#deep-paging - update the total_docs method to pull in the full count of records instead of the 10k default limited count.

This was mentioned in #1481 

endless ❤️  for searchkick