### PR TITLE
Better dependency injection on Index and Indexer

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -303,7 +303,7 @@ module Searchkick
 
   # private
   def self.indexer
-    Thread.current[:searchkick_indexer] ||= Indexer.new
+    Thread.current[:searchkick_indexer] ||= Indexer.new(self.client)
   end
 
   # private

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -315,16 +315,20 @@ module Searchkick
       Searchkick.client
     end
 
+    def indexer
+      Searchkick.indexer
+    end
+
     def queue_index(records)
-      Searchkick.indexer.queue(records.map { |r| RecordData.new(self, r).index_data })
+      indexer.queue(records.map { |r| RecordData.new(self, r).index_data })
     end
 
     def queue_delete(records)
-      Searchkick.indexer.queue(records.reject { |r| r.id.blank? }.map { |r| RecordData.new(self, r).delete_data })
+      indexer.queue(records.reject { |r| r.id.blank? }.map { |r| RecordData.new(self, r).delete_data })
     end
 
     def queue_update(records, method_name)
-      Searchkick.indexer.queue(records.map { |r| RecordData.new(self, r).update_data(method_name) })
+      indexer.queue(records.map { |r| RecordData.new(self, r).update_data(method_name) })
     end
 
     def relation_indexer

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -2,10 +2,11 @@
 # used to aggregate bulk callbacks across models
 module Searchkick
   class Indexer
-    attr_reader :queued_items
+    attr_reader :queued_items, :client
 
-    def initialize
+    def initialize(client)
       @queued_items = []
+      @client = client
     end
 
     def queue(items)
@@ -19,7 +20,7 @@ module Searchkick
 
       return if items.empty?
 
-      response = Searchkick.client.bulk(body: items)
+      response = client.bulk(body: items)
       if response["errors"]
         # note: delete does not set error when item not found
         first_with_error = response["items"].map do |item|


### PR DESCRIPTION
While trying to use multiple Elasticsearch servers, we realize Searchkick uses a single Indexer that uses the default client.
We just changed the indexer to have the client injected and the index to use a single function to get the indexer.