### PR TITLE
Add 'boost_and' option to Searchkick::Query

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -17,7 +17,7 @@ module Searchkick
       :with_score, :misspellings?, :scroll_id, :clear_scroll, :missing_records, :with_hit
 
     def initialize(klass, term = "*", **options)
-      unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost,
+      unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost, :boost_and,
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :explain,
         :fields, :highlight, :includes, :index_name, :indices_boost, :limit, :load,
         :match, :misspellings, :models, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
@@ -412,6 +412,17 @@ module Searchkick
                     }
                   },
                   should: {match_type => {field.sub(/\.word_(start|middle|end)\z/, ".analyzed") => qs.first}}
+                }
+              }
+            elsif options[:boost_and] && operator.to_s == "or"
+              queries_to_add << {
+                bool: {
+                  must: {
+                    bool: {
+                      should: q2
+                    }
+                  },
+                  should: qs.map { |q| {match_type => {field => q.merge({ operator: "and"})}} } 
                 }
               }
             else


### PR DESCRIPTION
First of all, thanks for a wonderful gem.

The "boost_and" option adds a second scoring query to fields that match with "ANY". This boosts the relevance of fields that also match the search query with an "AND" operator.

One of our examples would be e.g. an item in a store with title "cool jacket" with another field (lets call it "tag") equal to "Yellow".
Lets consider a user searches for an item with the query "Yellow jacket". We are using the "ANY" operator as we want to search each field in a document individually (title = jacket, tag = yellow),. However, in these scenarios we would like fields matching both words to be considered more relevant than fields only matching one (e.g. title=yellow jacket, tag=yellow => more relevant)

Please let us know if this might be a use case valid to merge to the repository or if it might be considered "to specific" to our use case.

