### PR TITLE
Adds compound boolean statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Select
 select: [:name]
 ```
 
+Compound Boolean
+
+```ruby
+# (in_stock: true OR backordered: false) AND (store_id: 1 OR store_id: 2)
+_and: [ { _or: [ {in_stock: true}, {backordered: false} ] }, { _or: [{store_id: 1}, {store_id: 2}] } ]
+```
+
 [These source filtering options are supported](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering)
 
 ### Results


### PR DESCRIPTION
Hi, it wasn't clear to me or [these people on StackOverflow](https://stackoverflow.com/questions/27833849/how-to-do-complex-querying-with-logical-operations-by-using-searchkick) how to combine boolean statements, so I think it might be worthwhile to add this to the README. I'm not 100% sure this is correct so feel free to make changes.