### PR TITLE
Don't search misspellings for an errored query

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -191,7 +191,7 @@ module Searchkick
     end
 
     def retry_misspellings?(response)
-      @misspellings_below && Results.new(searchkick_klass, response).total_count < @misspellings_below
+      @misspellings_below && response["error"].blank? && Results.new(searchkick_klass, response).total_count < @misspellings_below
     end
 
     private

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -191,7 +191,7 @@ module Searchkick
     end
 
     def retry_misspellings?(response)
-      @misspellings_below && response["error"].blank? && Results.new(searchkick_klass, response).total_count < @misspellings_below
+      @misspellings_below && response["error"].nil? && Results.new(searchkick_klass, response).total_count < @misspellings_below
     end
 
     private

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -34,10 +34,7 @@ class MultiSearchTest < Minitest::Test
   end
 
   def test_misspellings_below_with_errored_query
-    store_names ["Product A"]
-    clause_limit = Searchkick.opensearch? ? 1_024 : 65_536
-    search_string = (["Z"] * (clause_limit + 1)).join(" ")
-    products = Product.search(search_string, misspellings: {below: 1})
+    products = Product.search("abc", order: {bad_column: :asc}, misspellings: {below: 1})
     Searchkick.multi_search([products])
     assert products.error
   end

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -33,6 +33,15 @@ class MultiSearchTest < Minitest::Test
     assert_equal ["abc", "abd"], products.map(&:name)
   end
 
+  def test_misspellings_below_with_errored_query
+    store_names ["Product A"]
+    clause_limit = 1_024
+    search_string = (["Z"] * (clause_limit + 1)).join(" ")
+    products = Product.search(search_string, misspellings: {below: 1})
+    Searchkick.multi_search([products])
+    assert products.error
+  end
+
   def test_query_error
     products = Product.search("*", order: {bad_column: :asc})
     Searchkick.multi_search([products])

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -34,7 +34,7 @@ class MultiSearchTest < Minitest::Test
   end
 
   def test_misspellings_below_with_errored_query
-    products = Product.search("abc", order: {bad_column: :asc}, misspellings: {below: 1})
+    products = Product.search("abc", order: [:bad_field], misspellings: {below: 1})
     Searchkick.multi_search([products])
     assert products.error
   end

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -35,7 +35,7 @@ class MultiSearchTest < Minitest::Test
 
   def test_misspellings_below_with_errored_query
     store_names ["Product A"]
-    clause_limit = defined?(Elasticsearch) ? 65_536 : 1_024
+    clause_limit = Searchkick.opensearch? ? 1_024 : 65_536
     search_string = (["Z"] * (clause_limit + 1)).join(" ")
     products = Product.search(search_string, misspellings: {below: 1})
     Searchkick.multi_search([products])

--- a/test/multi_search_test.rb
+++ b/test/multi_search_test.rb
@@ -35,7 +35,7 @@ class MultiSearchTest < Minitest::Test
 
   def test_misspellings_below_with_errored_query
     store_names ["Product A"]
-    clause_limit = 1_024
+    clause_limit = defined?(Elasticsearch) ? 65_536 : 1_024
     search_string = (["Z"] * (clause_limit + 1)).join(" ")
     products = Product.search(search_string, misspellings: {below: 1})
     Searchkick.multi_search([products])


### PR DESCRIPTION
Hello, and thank you for this great library!

When executing a multisearch query that ultimately causes Elasticsearch to error and when using the misspellings option, we are seeing an unhandled exception bubble up from `searchkick`:

```
NoMethodError:
  undefined method `[]' for nil:NilClass
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/results.rb:92:in `total_count'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/query.rb:194:in `retry_misspellings?'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/multi_search.rb:22:in `block in perform_search'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/multi_search.rb:21:in `each'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/multi_search.rb:21:in `each_with_index'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/multi_search.rb:21:in `perform_search'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick/multi_search.rb:11:in `perform'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick.rb:188:in `block in multi_search'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/notifications.rb:206:in `block in instrument'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.1/lib/active_support/notifications.rb:206:in `instrument'
# /Users/david/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/searchkick-5.3.0/lib/searchkick.rb:187:in `multi_search'
# ./app/services/search/library.rb:136:in `block in execute_multi_search'
```

Our code that is (sometimes) triggering this exception is `Searchkick.multi_search([...])` where among the search options in `[...]` we include `misspellings: { below: 1, prefix_length: 3 }`. The exception occurs when conducting this search with a search string that contains a sufficiently large number of space-separated words.

As can be see from the above exception and stack trace, the exception is occurring [here](https://github.com/ankane/searchkick/blob/v5.3.0/lib/searchkick/results.rb#L92) (in `total_count`, called by `retry_misspellings?`)  https://github.com/ankane/searchkick/blob/243eb5276baa0b9d0e09e0f5fb6f1f7041e2da5e/lib/searchkick/results.rb#L92 because `response["hits"]` is `nil` but then we try to access `["total"]` on it.

This change avoids that exception by only attempting to compare `total_count` to `@misspellings_below` if `response["error"].blank?` (in which case, presumably, `response["hits"]` should be present (a Hash) when we access `["total"]` on it in `retry_misspellings?`).