### PR TITLE
Skip non-existant record warning when using `scope_results`

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -269,7 +269,7 @@ module Searchkick
                   # not ideal to return different types
                   # but this situation shouldn't be common
                   model: models.size == 1 ? models.first : models
-                }
+                } unless options[:scope_results]
               end
               result
             end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -84,7 +84,7 @@ class QueryTest < Minitest::Test
     skip unless activerecord?
 
     store_names ["Product A", "Product B"]
-    assert_warns "Records in search index do not exist in database" do
+    refute_warns do
       assert_search "product", ["Product A"], scope_results: ->(r) { r.where(name: "Product A") }
     end
   end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -92,6 +92,13 @@ class Minitest::Test
     assert_match "[searchkick] WARNING: #{message}", stderr
   end
 
+  def refute_warns
+    _, stderr = capture_io do
+      yield
+    end
+    refute_includes stderr, "[searchkick] WARNING:"
+  end
+
   def with_options(options, model = default_model)
     previous_options = model.searchkick_options.dup
     begin


### PR DESCRIPTION
Here's a naive first attempt at addressing https://github.com/ankane/searchkick/issues/1663, where records that have been filtered out by the `scope_results` are raising warnings. It skips missing records warnings whenever `search` is called with the `scope_results` option.

I took this approach because it silences the incorrect warnings without introducing any performance overhead. At first glance, I couldn't think of a way to check if records were missing from the database without performing an additional query for unscoped results.

The downside with this approach is that we'll no longer warnings for hits missing database records when using `scope_results`. This feels worth it to silence incorrect warnings, but I'm definitely open to other approaches here!