### PR TITLE
Use external version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,35 @@ class Product < ApplicationRecord
 end
 ```
 
+### Versioning
+
+[Elasticsearch Versioning Support](https://www.elastic.co/blog/elasticsearch-versioning-support). Searchkick can enable external version control for Elasticsearch by setting the version_type option. e.g.
+
+```ruby
+class Forbar < ApplicationRecord
+  searchkick version_type: :external_gte # Supported options: external, external_gt, external_gte. (Recommended: external_gte)
+
+
+  def data_version
+    current_time = if persisted?
+      raise "Missing updated_at" unless respond_to?(:updated_at)
+      updated_at
+    else # destroyed
+      Time.current # If soft deletion is used, the time of soft deletion should take priority here
+    end
+
+    # For Mongoid
+    # (time.to_r * 1_000).to_i # Millisecond
+
+    # For ActiveRecord
+    (current_time.to_r * 10 ** self.class.attribute_types["updated_at"].precision).to_i
+  end
+end
+```
+
+**Note: Because the [Elasticsearch document update operation](https://github.com/elastic/elasticsearch/blob/v7.17.22/server/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java#L77-#L85) does not support version control, when using [Partial Reindexing](#partial-reindexing)
+, version control will be ignored.**
+
 ## Intelligent Search
 
 The best starting point to improve your search **by far** is to track searches and conversions. [Searchjoy](https://github.com/ankane/searchjoy) makes it easy.

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -316,11 +316,11 @@ module Searchkick
     end
 
     def queue_index(records)
-      Searchkick.indexer.queue(records.map { |r| RecordData.new(self, r).index_data })
+      Searchkick.indexer.queue(records.map { |r| RecordData.new(self, r).index_data(required_version: true) })
     end
 
     def queue_delete(records)
-      Searchkick.indexer.queue(records.reject { |r| r.id.blank? }.map { |r| RecordData.new(self, r).delete_data })
+      Searchkick.indexer.queue(records.reject { |r| r.id.blank? }.map { |r| RecordData.new(self, r).delete_data(required_version: true) })
     end
 
     def queue_update(records, method_name)

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -24,8 +24,8 @@ module Searchkick
         # note: delete does not set error when item not found
         first_with_error = response["items"].map do |item|
           (item["index"] || item["delete"] || item["update"])
-        end.find { |item| item["error"] }
-        raise ImportError, "#{first_with_error["error"]} on item with id '#{first_with_error["_id"]}'"
+        end.find { |item| item["error"] && (ENV["RAISE_VERSION_CONFLICT_EXCEPTION"] || item["error"]["type"] != "version_conflict_engine_exception") }
+        raise ImportError, "#{first_with_error["error"]} on item with id '#{first_with_error["_id"]}'" if first_with_error
       end
 
       # maybe return response in future

--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -9,20 +9,20 @@ module Searchkick
       @record = record
     end
 
-    def index_data
-      data = record_data
+    def index_data(required_version: false)
+      data = record_data(required_version: required_version)
       data[:data] = search_data
       {index: data}
     end
 
-    def update_data(method_name)
-      data = record_data
+    def update_data(method_name, required_version: false)
+      data = record_data(required_version: required_version)
       data[:data] = {doc: search_data(method_name)}
       {update: data}
     end
 
-    def delete_data
-      {delete: record_data}
+    def delete_data(required_version: false)
+      {delete: record_data(required_version: required_version)}
     end
 
     # custom id can be useful for load: false
@@ -35,11 +35,17 @@ module Searchkick
       index.klass_document_type(record.class, ignore_type)
     end
 
-    def record_data
+    def record_data(required_version: false)
       data = {
         _index: index.name,
         _id: search_id
       }
+
+      if required_version && index.options[:version_type]
+        data[:version_type] = index.options[:version_type]
+        data[:version] = record.data_version
+      end
+
       data[:routing] = record.search_routing if record.respond_to?(:search_routing)
       data
     end

--- a/test/models/product.rb
+++ b/test/models/product.rb
@@ -20,7 +20,8 @@ class Product
     highlight: [:name],
     filterable: [:name, :color, :description],
     similarity: "BM25",
-    match: ENV["MATCH"] ? ENV["MATCH"].to_sym : nil
+    match: ENV["MATCH"] ? ENV["MATCH"].to_sym : nil,
+    version_type: :external_gte
 
   attr_accessor :conversions, :user_ids, :aisle, :details
 

--- a/test/reindex_test.rb
+++ b/test/reindex_test.rb
@@ -328,4 +328,18 @@ class ReindexTest < Minitest::Test
     Product.reindex
     Product.reindex # run twice for both index paths
   end
+
+  def test_index_version_conflict
+    previous_raise_version_conflict_exception = ENV["RAISE_VERSION_CONFLICT_EXCEPTION"]
+    ENV["RAISE_VERSION_CONFLICT_EXCEPTION"] = '1'
+
+    begin
+      product = Product.create(name: "Product Foobar")
+      product.updated_at = product.updated_at - 1.day
+      error = assert_raises(Searchkick::ImportError) { product.reindex }
+      assert_match 'version_conflict_engine_exception', error.message
+    ensure
+      ENV["RAISE_VERSION_CONFLICT_EXCEPTION"] = previous_raise_version_conflict_exception
+    end
+  end
 end


### PR DESCRIPTION
This PR integrates the external version control function of Elasticsearch with Searchkick, avoiding the problem of incorrect document data in Elasticsearch caused by concurrency during asynchronous synchronization of Searchkick data. For details, you can refer to [this article about Elasticsearch](https://www.elastic.co/blog/elasticsearch-versioning-support).

Note: Because the [Elasticsearch document update operation](https://github.com/elastic/elasticsearch/blob/v7.17.22/server/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java#L77-#L85) does not support version control, when using [Partial Reindexing](#partial-reindexing)
, version control will be ignored.



_PS: English is not my native language; please excuse typing errors._