### PR TITLE
Improve setup instructions in readme: Add step on setting up credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,32 @@ gem "opensearch-ruby" # select one
 
 The latest version works with Elasticsearch 7 and 8 and OpenSearch 1 and 2. For Elasticsearch 6, use version 4.6.3 and [this readme](https://github.com/ankane/searchkick/blob/v4.6.3/README.md).
 
+Store your Elasticsearch credentials somewhere, e.g. in the rails credentials storage or in environment variables. If you'd like do use the rails credentails storage, run:
+
+```shell
+EDITOR=nano rails credentials:edit
+```
+
+The credentials file could look like this:
+
+``` yaml
+elasticsearch:
+  password: "your-password"
+  ca_fingerprint: "your-ca-fingerprint"
+```
+
+Now pass those credentials to Searchkick's `client_options`, e.g. by creating an initializer `initializers/searchkick.rb`:
+
+```ruby
+# Assuming you're using Elasticsearch
+elastic_password = Rails.application.credentials.dig("elasticsearch", "password")
+elastic_ca_fingerprint = Rails.application.credentials.dig("elasticsearch", "ca_fingerprint")
+# Assuming your Elasticsearch user is named "elastic"
+Searchkick.client_options = { host: "https://elastic:#{elastic_password}@localhost:9200",
+                              transport_options: { ssl: { verify: false } },
+                              ca_fingerprint: elastic_ca_fingerprint }
+```
+
 Add searchkick to models you want to search.
 
 ```ruby


### PR DESCRIPTION
Hey, thanks so much for your work on Searchkick, it's awesome!

I'm currently in the process of using it for one of my projects and I got stuck while setting it up because the readme doesn't mention how to pass your Elasticsearch / Opensearch connection parameters to Searchkick. Took me some reading of the code (specifically `attr_accessor :client_options` in the `Searchkick` class) to understand how to pass them to Searchkick upon Rails initialization.

I added the steps to the readme. If this was somehow obvious and these steps are not helpful, feel free to close!