### PR TITLE
Use deep_merge for `model_options`

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -1,7 +1,7 @@
 module Searchkick
   module Model
     def searchkick(**options)
-      options = Searchkick.model_options.merge(options)
+      options = Searchkick.model_options.deep_merge(options)
 
       unknown_keywords = options.keys - [:_all, :_type, :batch_size, :callbacks, :case_sensitive, :conversions, :deep_paging, :default_fields,
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :knn, :language,


### PR DESCRIPTION
This PR adds support for nested parameters to `model_options`. For example,
```ruby
Searchkick.model_options = {
  settings: {
    number_of_shards: 1,
    number_of_replicas: 0,
  },
}
```

```ruby
class Product < ApplicationRecord
  searchkick settings: {
    analysis: {
      tokenizer: {
        kuromoji_with_dictionary: {...},
      },
      analyzer: { ... },
    },
  }
end
```
with code above, number_of_shards/replicas are ignored previously, but these are considered in this PR.
I guess this behaviour is expected because similar feature client_options is deep_merged.

Note: I haven't written any tests for this PR since there aren't any existing tests for model_options or client_options. Should I add some tests?