### PR TITLE
Fix module name typo in Railtie

### DIFF
--- a/lib/searchkick/railtie.rb
+++ b/lib/searchkick/railtie.rb
@@ -1,4 +1,4 @@
-module Searckick
+module Searchkick
   class Railtie < Rails::Railtie
     rake_tasks do
       load "tasks/searchkick.rake"


### PR DESCRIPTION
I just had a typo in my code:

```ruby
Searckick.search(
```

The error I received was surprising:
```
undefined method `search' for Searckick:Module
```

Turns out, you made the same typo that I did.