### PR TITLE
Fix incorrect OpenSearch detection on some distributions

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -132,7 +132,8 @@ module Searchkick
 
   def self.opensearch?
     unless defined?(@opensearch)
-      @opensearch = server_info["version"]["distribution"] == "opensearch"
+      @opensearch = server_info["version"]["distribution"] == "opensearch" ||
+        server_info.fetch("tagline", "").match?(/opensearch/i)
     end
     @opensearch
   end


### PR DESCRIPTION
Some OpenSearch servers don't seem to have a version distribution set, which causes this check to fail. As a fix we fallback to look at the tagline.

OpenSearch (AWS) 2.17 server info:
```json
{
  "name": "...",
  "cluster_name": "...",
  "cluster_uuid": "...",
  "version": {
    "number": "7.10.2",
    "build_type": "tar",
    "build_hash": "unknown",
    "build_date": "2024-11-18T04:22:32.407132088Z",
    "build_snapshot": false,
    "lucene_version": "9.11.1",
    "minimum_wire_compatibility_version": "7.10.0",
    "minimum_index_compatibility_version": "7.0.0"
  },
  "tagline": "The OpenSearch Project: https://opensearch.org/"
}
```