### PR TITLE
Ensure hits order is respected after model records are loaded when using sort

### DIFF
--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -243,7 +243,11 @@ module Searchkick
           grouped_hits.each do |index, index_hits|
             results[index] = {}
             index_models[index].each do |model|
-              results[index].merge!(results_query(model, index_hits).to_a.index_by { |r| r.id.to_s })
+              results[index].merge!(
+                results_query(model, index_hits).to_a
+                                                .sort_by { |r| index_hits.find_index { |hit| hit["_id"] == r.id.to_s } }
+                                                .index_by { |r| r.id.to_s }
+              )
             end
           end
 


### PR DESCRIPTION
Hi there, @ankane 

We have an issue on our project while using search with `sort` options then `kaminari` to paginate. 

While the query is properly built and return the proper result in ES, since we load the ActiveRecord using where, the records are not returned in proper order which breaks the purpose of the sort option. 

Let me know if we are missing anything