### PR TITLE
Add support for multiple methods in partial indexing

### DIFF
--- a/lib/searchkick/record_data.rb
+++ b/lib/searchkick/record_data.rb
@@ -49,7 +49,16 @@ module Searchkick
     def search_data(method_name = nil)
       partial_reindex = !method_name.nil?
 
-      source = record.send(method_name || :search_data)
+      if method_name.is_a?(Array)
+        source = {}
+        method_name.uniq.each do |method|
+          res = record.send(method)
+          raise "Method #{method} is not a hash" unless res.is_a?(Hash)
+          source.merge!(res)
+        end
+      else
+        source = record.send(method_name || :search_data)
+      end
 
       # conversions
       index.conversions_fields.each do |conversions_field|

--- a/lib/searchkick/record_indexer.rb
+++ b/lib/searchkick/record_indexer.rb
@@ -31,7 +31,7 @@ module Searchkick
           Searchkick::ReindexV2Job.perform_later(
             record.class.name,
             record.id.to_s,
-            method_name ? method_name.to_s : nil,
+            method_name.is_a?(Array) ? method_name.map(&:to_s) : method_name&.to_s,
             routing: routing,
             index_name: index.name
           )

--- a/lib/searchkick/record_indexer.rb
+++ b/lib/searchkick/record_indexer.rb
@@ -40,7 +40,7 @@ module Searchkick
             class_name: records.first.class.searchkick_options[:class_name],
             record_ids: records.map { |r| r.id.to_s },
             index_name: index.name,
-            method_name: method_name ? method_name.to_s : nil
+            method_name: method_name.is_a?(:Array) ? method_name.map(&:to_s) : method_name&.to_s,
           )
         end
       when :queue


### PR DESCRIPTION
This PR enhances Searchkick's partial indexing functionality by allowing multiple methods to be indexed simultaneously. Previously, only one method could be used at a time, requiring app-level workarounds to merge data from different sources (e.g., client data and buyer data).

We implemented this enhancement in our own project by patching Searchkick’s bulk reindexing, and the results have been positive. Given its usefulness, we believe it’s worth contributing to the main repository.

Changes:
✅ Modified bulk reindexing to support multiple indexing methods.
✅ Ensures backward compatibility with existing single-method indexing.

Let me know if any changes or improvements are needed! 

