### PR TITLE
Cross-cluster searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1809,6 +1809,28 @@ indices_boost: {Category => 2, Product => 1}
 
 Check out [this great post](https://www.tiagoamaro.com.br/2014/12/11/multi-tenancy-with-searchkick/) on the [Apartment](https://github.com/influitive/apartment) gem. Follow a similar pattern if you use another gem.
 
+## Cross-Cluster Searches
+
+To perform cross-cluster searches ([Elasticsearch](https://www.elastic.co/docs/solutions/search/cross-cluster-search) | [OpenSearch](https://docs.opensearch.org/docs/latest/search-plugins/cross-cluster-search/)), use the `ccs_clusters` option:
+
+```ruby
+Product.search("boots", ccs_clusters: ["remote_cluster"])
+# or
+Searchkick.search("boots", models: [Product, Category], ccs_clusters: ["remote_cluster"])
+```
+
+This will perform a search using both the local index (or indices) plus the one(s) in the clusters listed in the array. Assuming the index for `Product` is called `products_development`:
+
+```ruby
+Product.search("boots", ccs_clusters: ["remote_cluster"]) # will perform a search using the local products_development index + the remote_cluster:products_development index
+```
+
+If you want to perform a search using only the remote cluster indices, use the `ccs_exclude_local` option:
+
+```ruby
+Product.search("boots", ccs_clusters: ["remote_cluster"], ccs_exclude_local: true) # will perform a search using only the remote_cluster:products_development index
+```
+
 ## Scroll API
 
 Searchkick also supports the [scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results). Scrolling is not intended for real time user requests, but rather for processing large amounts of data.

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -18,10 +18,11 @@ module Searchkick
 
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost,
-        :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :clusters, :conversions, :conversions_term, :debug, :emoji, :exclude, :explain,
-        :fields, :highlight, :includes, :index_name, :indices_boost, :knn, :limit, :load,
-        :match, :misspellings, :models, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :scope_results, :scroll, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where]
+        :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :ccs_clusters, :ccs_exclude_local, :conversions,
+        :conversions_term, :debug, :emoji, :exclude, :explain, :fields, :highlight, :includes, :index_name, :indices_boost,
+        :knn, :limit, :load, :match, :misspellings, :models, :model_includes, :offset, :operator, :order, :padding,
+        :page, :per_page, :profile, :request_params, :routing, :scope_results, :scroll, :select, :similar, :smart_aggs,
+        :suggest, :total_entries, :track, :type, :where]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s
@@ -79,11 +80,14 @@ module Searchkick
           ["*,-.*"]
         end
 
-      # Handle cross-cluster search if clusters option is provided
-      if options[:clusters] && options[:clusters].any?
+      # Handle cross-cluster search if ccs_clusters option is provided
+      if options[:ccs_clusters] && options[:ccs_clusters].any?
         # For cross-cluster search, we need to prefix each index with its cluster
-        clusters = Array(options[:clusters])
+        clusters = Array(options[:ccs_clusters])
         index = indices.map { |idx| clusters.map { |cluster| "#{cluster}:#{idx}" } }.flatten.join(",")
+
+        # Include the indices without any cluster prefix unless ccs_exclude_local is true
+        index = "#{indices.join(',')},#{index}" unless options[:ccs_exclude_local]
       else
         index = indices.join(",")
       end

--- a/test/query_cross_cluster_test.rb
+++ b/test/query_cross_cluster_test.rb
@@ -1,0 +1,65 @@
+require_relative "test_helper"
+
+class QueryCrossClusterTest < Minitest::Test
+  def test_cross_cluster_search_basic
+    store_names ["Product A"]
+    query = Product.search("product", ccs_clusters: ["cluster1", "cluster2"])
+    assert_equal "products_test,cluster1:products_test,cluster2:products_test", query.params[:index]
+  end
+
+  def test_cross_cluster_search_basic_excluding_local_cluster
+    store_names ["Product A"]
+    query = Product.search("product", ccs_clusters: ["cluster1", "cluster2"], ccs_exclude_local: true)
+    assert_equal "cluster1:products_test,cluster2:products_test", query.params[:index]
+  end
+
+  # We don't want to trigger an actual search here (requires complex cluster setup),
+  # so simply instantiate a Searchkick::Query object and check the curl command
+  def test_cross_cluster_search_endpoint
+    store_names ["Product A"]
+    query = Searchkick::Query.new(Product, "product", ccs_clusters: ["cluster1", "cluster2"])
+    assert_includes CGI.unescape(query.to_curl), "/products_test,cluster1:products_test,cluster2:products_test/_search"
+  end
+
+  def test_cross_cluster_search_endpoint_excluding_local_cluster
+    store_names ["Product A"]
+    query = Searchkick::Query.new(Product, "product", ccs_clusters: ["cluster1", "cluster2"], ccs_exclude_local: true)
+    assert_includes CGI.unescape(query.to_curl), "/cluster1:products_test,cluster2:products_test/_search"
+  end
+
+  def test_cross_cluster_search_multiple_indices
+    store_names ["Product A"]
+    query = Searchkick.search("product", models: [Product, Store], ccs_clusters: ["cluster1"])
+    assert_equal "products_test,stores_test,cluster1:products_test,cluster1:stores_test", query.params[:index]
+  end
+
+  def test_cross_cluster_search_multiple_indices_excluding_local_cluster
+    store_names ["Product A"]
+    query = Searchkick.search("product", models: [Product, Store], ccs_clusters: ["cluster1"], ccs_exclude_local: true)
+    assert_equal "cluster1:products_test,cluster1:stores_test", query.params[:index]
+  end
+
+  def test_cross_cluster_search_custom_index
+    store_names ["Product A"]
+    query = Product.search("product", index_name: "custom_index", ccs_clusters: ["cluster1"])
+    assert_equal "custom_index,cluster1:custom_index", query.params[:index]
+  end
+
+  def test_cross_cluster_search_custom_index_excluding_local_cluster
+    store_names ["Product A"]
+    query = Product.search("product", index_name: "custom_index", ccs_clusters: ["cluster1"], ccs_exclude_local: true)
+    assert_equal "cluster1:custom_index", query.params[:index]
+  end
+
+  def test_cross_cluster_search_empty_clusters
+    store_names ["Product A"]
+    query = Product.search("product", ccs_clusters: [])
+    assert_equal "products_test", query.params[:index]
+  end
+
+  def test_cross_cluster_search_nil_clusters
+    store_names ["Product A"]
+    query = Product.search("product", ccs_clusters: nil)
+    assert_equal "products_test", query.params[:index]
+  end
+end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -88,42 +88,4 @@ class QueryTest < Minitest::Test
       assert_search "product", ["Product A"], scope_results: ->(r) { r.where(name: "Product A") }
     end
   end
-
-  def test_cross_cluster_search_basic
-    store_names ["Product A"]
-    query = Product.search("product", clusters: ["cluster1", "cluster2"])
-    assert_equal "cluster1:products_test,cluster2:products_test", query.params[:index]
-  end
-
-  # We don't want to trigger an actual search here (requires complex cluster setup),
-  # so simply instantiate a Searchkick::Query object and check the curl command
-  def test_cross_cluster_search_endpoint
-    store_names ["Product A"]
-    query = Searchkick::Query.new(Product, "product", clusters: ["cluster1", "cluster2"])
-    assert_includes CGI.unescape(query.to_curl), "/cluster1:products_test,cluster2:products_test/_search"
-  end
-
-  def test_cross_cluster_search_multiple_indices
-    store_names ["Product A"]
-    query = Searchkick.search("product", models: [Product, Store], clusters: ["cluster1"])
-    assert_equal "cluster1:products_test,cluster1:stores_test", query.params[:index]
-  end
-
-  def test_cross_cluster_search_custom_index
-    store_names ["Product A"]
-    query = Product.search("product", index_name: "custom_index", clusters: ["cluster1"])
-    assert_equal "cluster1:custom_index", query.params[:index]
-  end
-
-  def test_cross_cluster_search_empty_clusters
-    store_names ["Product A"]
-    query = Product.search("product", clusters: [])
-    assert_equal "products_test", query.params[:index]
-  end
-
-  def test_cross_cluster_search_nil_clusters
-    store_names ["Product A"]
-    query = Product.search("product", clusters: nil)
-    assert_equal "products_test", query.params[:index]
-  end
 end


### PR DESCRIPTION
This Pull Request adds the ability to execute Cross-Cluster Searches (CCS).

[Elasticsearch docs](https://www.elastic.co/docs/solutions/search/cross-cluster-search) | [OpenSearch docs](https://docs.opensearch.org/docs/latest/search-plugins/cross-cluster-search/)

CCS is becoming more and more critical as regional data governance and regulations strengthen. In our product, the data for US companies remains stored at rest in US data centers, while data from European companies is stored in Europe. The same is applied to OpenSearch indices. CCS is paramount to allowing admin tools and customers with global reach to have a unified search experience (i.e., a single search provides ranking, pagination out-of-the-box, as opposed to running separate searches and then combining the results).
 
The implementation involves only minor additions to allow specifying remote indices (e.g., remote_cluster:index_name) in search queries. This aligns well with Searchkick's philosophy of offering full Elasticsearch/OpenSearch power while keeping the developer interface simple, and allows developers who need to use CCS to take full advantage of all the fantastic features of Searchkick.

The CCS functionality is optional and does not affect users who don’t configure remote clusters. It’s a non-breaking enhancement that integrates cleanly into the current Searchkick API and index naming structure.

I'm open to answering questions and/or changing the implementation, tests, and documentation.
