### PR TITLE
Add Elastic Serverless support

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -150,6 +150,10 @@ module Searchkick
     Gem::Version.new(server_version.split("-")[0]) < Gem::Version.new(version.split("-")[0])
   end
 
+  def self.serverless?
+    @serverless ||= server_info["version"]["build_flavor"] == "serverless"
+  end
+
   # private
   def self.knn_support?
     if opensearch?

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -122,17 +122,17 @@ module Searchkick
             },
             searchkick_suggest_shingle: {
               type: "shingle",
-              max_shingle_size: 5
+              max_shingle_size: serverless? ? nil : 5
             },
             searchkick_edge_ngram: {
               type: "edge_ngram",
-              min_gram: 1,
-              max_gram: 50
+              min_gram: serverless? ? nil : 1,
+              max_gram: serverless? ? nil : 50
             },
             searchkick_ngram: {
               type: "ngram",
-              min_gram: 1,
-              max_gram: 50
+              min_gram: serverless? ? nil : 1,
+              max_gram: serverless? ? nil : 50
             },
             searchkick_stemmer: {
               # use stemmer if language is lowercase, snowball otherwise
@@ -164,10 +164,12 @@ module Searchkick
         settings[:similarity] = {default: {type: options[:similarity]}}
       end
 
-      settings[:index] = {
-        max_ngram_diff: 49,
-        max_shingle_diff: 4
-      }
+      if !serverless?
+        settings[:index] = {
+          max_ngram_diff: 49,
+          max_shingle_diff: 4
+        }
+      end
 
       if options[:knn]
         unless Searchkick.knn_support?
@@ -631,6 +633,10 @@ module Searchkick
 
     def below73?
       Searchkick.server_below?("7.3.0")
+    end
+
+    def serverless?
+      Searchkick.serverless?
     end
   end
 end

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -1145,16 +1145,16 @@ module Searchkick
                   case op
                   when :gt
                     # TODO always use gt in Searchkick 6
-                    below90? ? {from: op_value, include_lower: false} : {gt: op_value}
+                    below90? && !serverless? ? {from: op_value, include_lower: false} : {gt: op_value}
                   when :gte
                     # TODO always use gte in Searchkick 6
-                    below90? ? {from: op_value, include_lower: true} : {gte: op_value}
+                    below90? && !serverless? ? {from: op_value, include_lower: true} : {gte: op_value}
                   when :lt
                     # TODO always use lt in Searchkick 6
-                    below90? ? {to: op_value, include_upper: false} : {lt: op_value}
+                    below90? && !serverless? ? {to: op_value, include_upper: false} : {lt: op_value}
                   when :lte
                     # TODO always use lte in Searchkick 6
-                    below90? ? {to: op_value, include_upper: true} : {lte: op_value}
+                    below90? && !serverless? ? {to: op_value, include_upper: true} : {lte: op_value}
                   else
                     raise ArgumentError, "Unknown where operator: #{op.inspect}"
                   end
@@ -1318,6 +1318,10 @@ module Searchkick
 
     def below90?
       Searchkick.server_below?("9.0.0")
+    end
+
+    def serverless?
+      Searchkick.serverless?
     end
   end
 end


### PR DESCRIPTION
- Add new `serverless?` method to detect if serverless.
- Disable unsupported options
- Modified range queries since it appears serverless currently reports 8.11, but expects the newer `gt`, `gte`, `lt`, and `lte` format.
