### PR TITLE
Allow a custom class to be used in place of HashWrapper

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -19,7 +19,7 @@ module Searchkick
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost,
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :explain,
-        :fields, :highlight, :includes, :index_name, :indices_boost, :knn, :limit, :load,
+        :fields, :highlight, :includes, :index_name, :indices_boost, :knn, :limit, :load, :result_wrapper_class,
         :match, :misspellings, :models, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
         :request_params, :routing, :scope_results, :scroll, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
@@ -144,7 +144,8 @@ module Searchkick
         total_entries: options[:total_entries],
         index_mapping: @index_mapping,
         suggest: options[:suggest],
-        scroll: options[:scroll]
+        scroll: options[:scroll],
+        result_wrapper_class: options[:result_wrapper_class]
       }
 
       if options[:debug]

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -19,9 +19,9 @@ module Searchkick
     def initialize(klass, term = "*", **options)
       unknown_keywords = options.keys - [:aggs, :block, :body, :body_options, :boost,
         :boost_by, :boost_by_distance, :boost_by_recency, :boost_where, :conversions, :conversions_term, :debug, :emoji, :exclude, :explain,
-        :fields, :highlight, :includes, :index_name, :indices_boost, :knn, :limit, :load, :result_wrapper_class,
+        :fields, :highlight, :includes, :index_name, :indices_boost, :knn, :limit, :load,
         :match, :misspellings, :models, :model_includes, :offset, :operator, :order, :padding, :page, :per_page, :profile,
-        :request_params, :routing, :scope_results, :scroll, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where]
+        :request_params, :result_wrapper_class, :routing, :scope_results, :scroll, :select, :similar, :smart_aggs, :suggest, :total_entries, :track, :type, :where]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       term = term.to_s

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -293,7 +293,8 @@ module Searchkick
               end
 
               result["id"] ||= result["_id"] # needed for legacy reasons
-              [HashWrapper.new(result), hit]
+              result_wrapper_class = options[:result_wrapper_class] || HashWrapper
+              [result_wrapper_class.new(result), hit]
             end
         end
 

--- a/test/load_test.rb
+++ b/test/load_test.rb
@@ -21,6 +21,11 @@ class LoadTest < Minitest::Test
     assert_kind_of Searchkick::HashWrapper, Product.search("product", load: false, includes: [:store]).first
   end
 
+  def test_false_with_result_wrapper_class
+    store_names ["Product A"]
+    assert_kind_of Hashie::Mash, Product.search("product", load: false, result_wrapper_class: Hashie::Mash).first
+  end
+
   def test_false_nested_object
     aisle = {"id" => 1, "name" => "Frozen"}
     store [{name: "Product A", aisle: aisle}]


### PR DESCRIPTION
This PR introduces the ability to configure a custom wrapper class for Searchkick results, replacing the default `Searchkick::HashWrapper`.

This allows us to avoid loading full ActiveRecord models while:
- Customize the behavior and structure of search results.
- Make small tweaks to the indexed data before it's used in the application (e.g., computed fields, normalized keys, etc.).

The new wrapper class provides a flexible way to shape search results without compromising performance or requiring model hydration.