### PR TITLE
Add backup index for more reliable zero-downtime reindexing

### DIFF
--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -7,7 +7,7 @@ module Searchkick
         :filterable, :geo_shape, :highlight, :ignore_above, :index_name, :index_prefix, :inheritance, :knn, :language,
         :locations, :mappings, :match, :max_result_window, :merge_mappings, :routing, :searchable, :search_synonyms, :settings, :similarity,
         :special_characters, :stem, :stemmer, :stem_conversions, :stem_exclusion, :stemmer_override, :suggest, :synonyms, :text_end,
-        :text_middle, :text_start, :unscope, :word, :word_end, :word_middle, :word_start]
+        :text_middle, :text_start, :unscope, :word, :word_end, :word_middle, :word_start, :backup_index_name]
       raise ArgumentError, "unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       raise "Only call searchkick once per model" if respond_to?(:searchkick_index)


### PR DESCRIPTION
If using model.reindex to directly rebuild the index, the following issues may exist:

1. The new index may contain dirty data. For example:
The user rebuild the product index, product A's data is written to the new index, but during the index rebuild, product A is modified or directly removed. At this time, the new index is unaware of these changes.

2. The new index may have issues. For example:
The user adjusted some field properties (index/doc_values) to save disk space, but later found that performance was affected. If  directly rolled back to the old one, the old index's data is outdated, and the index can only be rebuilt again.


This PR introduces a backup index to achieve duplication, supporting more reliable index reconstruction, details can be found in the modified content of the README.