### PR TITLE
Document search and scroll request support X-Opaque-Id header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1832,6 +1832,26 @@ end
 products.clear_scroll
 ```
 
+## Search slow log location
+
+Pass an `opaque_id` to track queries location.
+The `elasticsearch.slowlog.id` field record `opaque_id` in [Elasticsearch's slow logs](https://www.elastic.co/docs/reference/elasticsearch/index-settings/slow-log#slow-log-format).
+
+```ruby
+Product.search("pears", opaque_id: "xxx")
+```
+
+This sends the `X-Opaque-Id: xxx` header with the request.
+
+It also works with `multi_search`:
+
+```ruby
+Searchkick.multi_search([
+  Product.search("apples"),
+  Product.search("pears")
+], opaque_id: "xxx")
+```
+
 ## Deep Paging
 
 By default, Elasticsearch and OpenSearch limit paging to the first 10,000 results. [Here’s why](https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html). We don’t recommend changing this, but if you really need all results, you can use:

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -194,7 +194,7 @@ module Searchkick
     Relation.new(klass, term, **options)
   end
 
-  def self.multi_search(queries)
+  def self.multi_search(queries, opaque_id: nil)
     return if queries.empty?
 
     queries = queries.map { |q| q.send(:query) }
@@ -203,7 +203,7 @@ module Searchkick
       body: queries.flat_map { |q| [q.params.except(:body).to_json, q.body.to_json] }.map { |v| "#{v}\n" }.join
     }
     ActiveSupport::Notifications.instrument("multi_search.searchkick", event) do
-      MultiSearch.new(queries).perform
+      MultiSearch.new(queries, opaque_id: opaque_id).perform
     end
   end
 

--- a/lib/searchkick/multi_search.rb
+++ b/lib/searchkick/multi_search.rb
@@ -2,8 +2,9 @@ module Searchkick
   class MultiSearch
     attr_reader :queries
 
-    def initialize(queries)
+    def initialize(queries, opaque_id: nil)
       @queries = queries
+      @opaque_id = opaque_id
     end
 
     def perform
@@ -15,7 +16,7 @@ module Searchkick
     private
 
     def perform_search(search_queries, perform_retry: true)
-      responses = client.msearch(body: search_queries.flat_map { |q| [q.params.except(:body), q.body] })["responses"]
+      responses = client.msearch(opaque_id: @opaque_id, body: search_queries.flat_map { |q| [q.params.except(:body), q.body] })["responses"]
 
       retry_queries = []
       search_queries.each_with_index do |query, i|

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -193,7 +193,7 @@ module Searchkick
       else
         begin
           # TODO Active Support notifications for this scroll call
-          Results.new(@klass, Searchkick.client.scroll(scroll: options[:scroll], body: {scroll_id: scroll_id}), @options)
+          Results.new(@klass, Searchkick.client.scroll(opaque_id: options[:opaque_id], scroll: options[:scroll], body: {scroll_id: scroll_id}), options)
         rescue => e
           if Searchkick.not_found_error?(e) && e.message =~ /search_context_missing_exception/i
             raise Error, "Scroll id has expired"


### PR DESCRIPTION
## Purpose

When performing Elasticsearch document queries, by declaring a specific X-Opaque-Id request header, so that slow logs can record this information, making it convenient to locate the code position.

## Changed

-  `Searchkick.multi_search` support `opaque_id` argument
- `Searchkick.Query` options support `opaque_id`

## Elasticsearch References

- [Slow log settings](https://www.elastic.co/docs/reference/elasticsearch/index-settings/slow-log)
- [X-Opaque-Id HTTP header](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/api-conventions#x-opaque-id)