### PR TITLE
Issue #1597 - Fix unscoped detection to allow search within unscoped blocks.

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -352,7 +352,7 @@ module Searchkick
   # it's a bit tricky, but this seems to work
   def self.relation?(klass)
     if klass.respond_to?(:current_scope)
-      !klass.current_scope.nil?
+      !(klass.current_scope.nil? || klass.send(:scope_attributes) == {})
     else
       klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
     end

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -8,6 +8,16 @@ class SearchTest < Minitest::Test
     assert_equal "search must be called on model, not relation", error.message
   end
 
+  def test_search_unscoped
+    skip unless activerecord?
+    
+    Product.where(name: "Test").unscoped do
+      assert_nothing_raised do
+        Product.search("*", load: false)
+      end
+    end
+  end
+
   def test_body
     store_names ["Dollar Tree"], Store
     assert_equal ["Dollar Tree"], Store.search(body: {query: {match: {name: "dollar"}}}, load: false).map(&:name)


### PR DESCRIPTION
### Summary
This PR fixes an issue where `Product.search` could not be called inside an `unscoped` block.  
Previously, Searchkick raised an error when attempting to run searches within `ActiveRecord#unscoped`,  
due to overly strict detection logic.

### Changes
- Updated `relation?` check in `lib/searchkick.rb` to properly handle `unscoped` blocks.
- Added a test (`test_search_unscoped`) to confirm search works as expected within `unscoped`.

### Example
```ruby
Product.where(name: "Test").unscoped do
  Product.search("*", load: false) # ✅ now works without raising error
end
```
Fixes #1597 - Thanks to [@Roguelazer](https://github.com/Roguelazer) for reporting this!