### PR TITLE
Fix uninitialized constant Searchkick::Mongoid in relation? when Mongoid is not defined

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -355,6 +355,8 @@ module Searchkick
       !klass.current_scope.nil?
     elsif defined?(Mongoid)
       klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
+    else
+      false
     end
   end
 


### PR DESCRIPTION
Currently, Searchkick.relation? assumes that if a class does not respond to current_scope, it must be a Mongoid relation. This causes a NameError: uninitialized constant Searchkick::Mongoid in applications that do not use Mongoid.

This PR updates the method to only reference Mongoid::Criteria and Mongoid::Threaded if Mongoid is actually defined.