### PR TITLE
Fix links to "www.elasticsearch.org" [skip ci]

### DIFF
--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -359,7 +359,7 @@ module Searchkick
     end
 
     # https://gist.github.com/jarosan/3124884
-    # http://www.elasticsearch.org/blog/changing-mapping-with-zero-downtime/
+    # https://www.elastic.co/blog/changing-mapping-with-zero-downtime/
     def full_reindex(relation, import: true, resume: false, retain: false, mode: nil, refresh_interval: nil, scope: nil, wait: nil, job_options: nil)
       raise ArgumentError, "wait only available in :async mode" if !wait.nil? && mode != :async
       raise ArgumentError, "Full reindex does not support :queue mode - use :async mode instead" if mode == :queue

--- a/lib/searchkick/index_options.rb
+++ b/lib/searchkick/index_options.rb
@@ -524,7 +524,7 @@ module Searchkick
 
       dynamic_fields = {
         # analyzed field must be the default field for include_in_all
-        # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
+        # https://www.elastic.co/guide/reference/mapping/multi-field-type/
         # however, we can include the not_analyzed field in _all
         # and the _all index analyzer will take care of it
         "{name}" => keyword_mapping
@@ -544,7 +544,7 @@ module Searchkick
         end
       end
 
-      # http://www.elasticsearch.org/guide/reference/mapping/multi-field-type/
+      # https://www.elastic.co/guide/reference/mapping/multi-field-type/
       multi_field = dynamic_fields["{name}"].merge(fields: dynamic_fields.except("{name}"))
 
       mappings = {


### PR DESCRIPTION
A redirect from "www.elasticsearch.org" doesn't keep a path. So a link doesn't go to the expected page.
This PR updates the domain to "elastic.co" to go to a page correctly.

