### PR TITLE
[BUG] Fix Relation#inspect failing due to private Results#results

### DIFF
--- a/lib/searchkick/relation.rb
+++ b/lib/searchkick/relation.rb
@@ -22,7 +22,7 @@ module Searchkick
 
     # same as Active Record
     def inspect
-      entries = results.first(11).map!(&:inspect)
+      entries = private_execute.first(11).map!(&:inspect)
       entries[10] = "..." if entries.size == 11
       "#<#{self.class.name} [#{entries.join(', ')}]>"
     end


### PR DESCRIPTION
### Bug: Relation#inspect raises NoMethodError in Searchkick 6.0+

In v6.0, `Results#results` was made private, breaking `Relation#inspect` which relied on delegating the `results` call through `delegate_missing_to`. Since `delegate_missing_to` uses `public_send`, it cannot access private methods.

 Calling inspect on a search relation fails with `NoMethodError: undefined local variable or method 'results'`:
```ruby
  Product.search("test").inspect
  # => NoMethodError: undefined local variable or method `results' for an instance of Searchkick::Relation
  ```

Fixed by calling `private_execute.first(11)` directly instead of `results.first(11)`.