### PR TITLE
Add Searchkick::Relation#per as alias for per_page

### DIFF
--- a/lib/searchkick/relation.rb
+++ b/lib/searchkick/relation.rb
@@ -409,6 +409,8 @@ module Searchkick
       end
     end
 
+    alias_method :per, :per_page
+
     def per_page!(value)
       check_loaded
       # TODO set limit?


### PR DESCRIPTION
I had the same issue as [#1572](https://github.com/ankane/searchkick/issues/1572) where when using with the `api-pagination` gem, I got errors due to `per` method not being present. IDK how experimental or not the chaining api is now, but I just aliased `per_page` which resolves the issue. Feel free to amend or LMK if you want something different here.
