### PR TITLE
`Searchkick::Relation#aggs` supports positional and keyword args

### DIFF
--- a/lib/searchkick/relation.rb
+++ b/lib/searchkick/relation.rb
@@ -27,17 +27,19 @@ module Searchkick
       "#<#{self.class.name} [#{entries.join(', ')}]>"
     end
 
-    def aggs(value = NO_DEFAULT_VALUE)
-      if value == NO_DEFAULT_VALUE
+    def aggs(*args, **kwargs)
+      if args.empty? && kwargs.empty?
         private_execute.aggs
       else
-        clone.aggs!(value)
+        clone.aggs!(*args, **kwargs)
       end
     end
 
-    def aggs!(value)
+    def aggs!(*args, **kwargs)
       check_loaded
-      (@options[:aggs] ||= {}).merge!(value)
+      @options[:aggs] ||= {}
+      @options[:aggs].merge!(args.to_h { |arg| [arg, {}] })
+      @options[:aggs].merge!(kwargs)
       self
     end
 

--- a/test/aggs_test.rb
+++ b/test/aggs_test.rb
@@ -238,6 +238,12 @@ class AggsTest < Minitest::Test
     assert_equal ({2 => 2}), buckets_as_hash(Product.search("Product").where(color: "red").aggs(store_id: {where: {in_stock: false}}).smart_aggs(false).aggs["store_id"])
   end
 
+  def test_relation_with_positional_args
+    aggs = Product.search("Product").aggs(:color, store_id: {where: {in_stock: true}}).aggs
+    assert_equal ({"blue" => 1, "green" => 1, "red" => 1}), buckets_as_hash(aggs["color"])
+    assert_equal ({1 => 1}), buckets_as_hash(aggs["store_id"])
+  end
+
   protected
 
   def search_aggregate_by_day_with_time_zone(query, time_zone = '-8:00')


### PR DESCRIPTION
Fixes https://github.com/ankane/searchkick/issues/1738