### PR TITLE
Add rescore_vector support for BBQ quantized KNN indices

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -146,6 +146,10 @@ module Searchkick
     end
   end
 
+  def self.rescore_vector_support?
+    !opensearch? && !server_below?("8.18.0")
+  end
+
   def self.search(term = "*", model: nil, **options, &block)
     options = options.dup
     klass = model

--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -973,6 +973,7 @@ module Searchkick
       exact = field_options[:distance].nil? || distance != field_options[:distance] if exact.nil?
       k = per_page + offset
       ef_search = knn[:ef_search]
+      rescore_vector = knn[:rescore_vector]
       filter = payload.delete(:query)
 
       if distance.nil?
@@ -1073,12 +1074,25 @@ module Searchkick
             }
           }
         else
+          if rescore_vector && !Searchkick.rescore_vector_support?
+            raise Error, "rescore_vector requires Elasticsearch 8.18+"
+          end
+
+          rescore_vector_options =
+            if rescore_vector
+              oversample = rescore_vector == true ? nil : rescore_vector
+              {rescore_vector: {oversample: oversample}.compact}
+            else
+              {}
+            end
+
           payload[:knn] = {
             field: field,
             query_vector: vector,
             k: k,
             filter: filter
           }.merge(ef_search ? {num_candidates: ef_search} : {})
+           .merge(rescore_vector_options)
         end
       end
     end

--- a/test/knn_test.rb
+++ b/test/knn_test.rb
@@ -205,6 +205,29 @@ class KnnTest < Minitest::Test
     assert_order "*", ["A", "B"], knn: {field: :embedding, vector: [1, 2, 3], ef_search: 20}, limit: 10
   end
 
+  def test_rescore_vector
+    skip unless Searchkick.rescore_vector_support?
+
+    store [{name: "A", embedding_bbq: [1, 2, 3]}, {name: "B", embedding_bbq: [-1, -2, -3]}, {name: "C"}]
+    assert_order "*", ["A", "B"], knn: {field: :embedding_bbq, vector: [1, 2, 3], rescore_vector: true}
+  end
+
+  def test_rescore_vector_with_oversample
+    skip unless Searchkick.rescore_vector_support?
+
+    store [{name: "A", embedding_bbq: [1, 2, 3]}, {name: "B", embedding_bbq: [-1, -2, -3]}, {name: "C"}]
+    assert_order "*", ["A", "B"], knn: {field: :embedding_bbq, vector: [1, 2, 3], rescore_vector: 1.5}
+  end
+
+  def test_rescore_vector_unsupported
+    skip unless Searchkick.opensearch? || Searchkick.server_below?("8.18.0")
+
+    error = assert_raises(Searchkick::Error) do
+      Product.search("*", knn: {field: :embedding, vector: [1, 2, 3], rescore_vector: true})
+    end
+    assert_match "rescore_vector requires Elasticsearch 8.18+", error.message
+  end
+
   private
 
   def assert_approx(approx, field, distance, **knn_options)

--- a/test/models/product.rb
+++ b/test/models/product.rb
@@ -26,7 +26,8 @@ class Product
       embedding: {dimensions: 3, distance: "cosine", m: 16, ef_construction: 100},
       embedding2: {dimensions: 3, distance: "inner_product"},
       embedding3: {dimensions: 3, distance: "euclidean"}
-    }.merge(Searchkick.opensearch? ? {} : {embedding4: {dimensions: 3}}) : nil
+    }.merge(Searchkick.opensearch? ? {} : {embedding4: {dimensions: 3}})
+     .merge(Searchkick.rescore_vector_support? ? {embedding_bbq: {dimensions: 3, distance: "cosine", quantization: "bbq"}} : {}) : nil
 
   attr_accessor :conversions, :conversions_v2, :user_ids, :aisle, :details
 


### PR DESCRIPTION
## Summary

- Adds `rescore_vector` as an accepted option in `knn:` search queries for Elasticsearch 8.18+
- Adds `Searchkick.rescore_vector_support?` version guard
- The index mapping side (`quantization: "bbq"` → `bbq_hnsw` type) was already supported; this completes the query side

## Background

Elasticsearch's BBQ (Better Binary Quantization) compresses vectors to ~1/25th of their raw size while keeping good recall — but accuracy can degrade at scale. The `rescore_vector` parameter (ES 8.18+) rescores the initial ANN results against the full-precision vectors, recovering recall accuracy lost to quantization.

## Usage

```ruby
# Index with BBQ (already worked)
class Product < ApplicationRecord
  searchkick knn: {
    embedding: {dimensions: 384, distance: "cosine", quantization: "bbq"}
  }
end

# Query with rescore_vector (new)
Product.search("*", knn: {
  field: :embedding,
  vector: my_vector,
  distance: "cosine",
  rescore_vector: true      # use ES default oversample factor
  # rescore_vector: 1.5     # or explicit oversample factor
})
```

## Test plan

- `test_rescore_vector` — verifies correct result ordering with `rescore_vector: true` on a BBQ index (skipped unless ES 8.18+)
- `test_rescore_vector_with_oversample` — same with a numeric oversample factor
- `test_rescore_vector_unsupported` — verifies a clear error is raised on OpenSearch or ES < 8.18