### PR TITLE
Replace ignore_missing boolean with on_missing options

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -57,6 +57,8 @@ module Searchkick
   class DangerousOperation < Error; end
   class ImportError < Error; end
 
+  ON_MISSING_VALUES = [:raise, :ignore, :full].freeze
+
   class << self
     attr_accessor :search_method_name, :timeout, :models, :client_options, :redis, :index_prefix, :index_suffix, :queue_name, :model_options, :client_type, :parent_job
     attr_writer :client, :env, :search_timeout
@@ -272,6 +274,33 @@ module Searchkick
 
   def self.warn(message)
     super("[searchkick] WARNING: #{message}")
+  end
+
+  def self.normalize_on_missing(on_missing, ignore_missing)
+    if !ignore_missing.nil? && !on_missing.nil?
+      raise ArgumentError, "Cannot pass both on_missing and ignore_missing"
+    end
+
+    # Use a nil check instead of present? to distinguish between ignore_missing: nil (unset),
+    # ignore_missing: true, and ignore_missing: false. 
+    if !ignore_missing.nil?
+      case ignore_missing
+      when true
+        Searchkick.warn "ignore_missing is deprecated, use on_missing: :ignore instead of ignore_missing: true"
+      when false
+        Searchkick.warn "ignore_missing is deprecated, use on_missing: :raise instead of ignore_missing: false"
+      end
+      return ignore_missing ? :ignore : :raise
+    end
+
+    return :raise if on_missing.nil?
+
+    on_missing = on_missing.to_sym if on_missing.is_a?(String)
+    unless ON_MISSING_VALUES.include?(on_missing)
+      raise ArgumentError,
+      "Invalid value for on_missing: #{on_missing.inspect} (expected one of #{ON_MISSING_VALUES.map(&:inspect).join(', ')})"
+    end
+    on_missing
   end
 
   # private

--- a/lib/searchkick/bulk_reindex_job.rb
+++ b/lib/searchkick/bulk_reindex_job.rb
@@ -2,7 +2,8 @@ module Searchkick
   class BulkReindexJob < Searchkick.parent_job.constantize
     queue_as { Searchkick.queue_name }
 
-    def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil, ignore_missing: nil)
+    def perform(class_name:, record_ids: nil, index_name: nil, method_name: nil, batch_id: nil, min_id: nil, max_id: nil, ignore_missing: nil, on_missing: nil)
+      on_missing = Searchkick.normalize_on_missing(on_missing, ignore_missing)
       model = Searchkick.load_model(class_name)
       index = model.searchkick_index(name: index_name)
 
@@ -12,7 +13,7 @@ module Searchkick
       relation = Searchkick.load_records(relation, record_ids)
       relation = relation.search_import if relation.respond_to?(:search_import)
 
-      RecordIndexer.new(index).reindex(relation, mode: :inline, method_name: method_name, ignore_missing: ignore_missing, full: false)
+      RecordIndexer.new(index).reindex(relation, mode: :inline, method_name: method_name, on_missing: on_missing, full: false)
       RelationIndexer.new(index).batch_completed(batch_id) if batch_id
     end
   end

--- a/lib/searchkick/index.rb
+++ b/lib/searchkick/index.rb
@@ -164,11 +164,11 @@ module Searchkick
     end
     alias_method :import, :bulk_index
 
-    def bulk_update(records, method_name, ignore_missing: nil)
+    def bulk_update(records, method_name, on_missing: nil)
       return if records.empty?
 
       notify_bulk(records, "Update") do
-        queue_update(records, method_name, ignore_missing: ignore_missing)
+        queue_update(records, method_name, on_missing: on_missing)
       end
     end
 
@@ -211,14 +211,15 @@ module Searchkick
 
     # note: this is designed to be used internally
     # so it does not check object matches index class
-    def reindex(object, method_name: nil, ignore_missing: nil, full: false, **options)
+    def reindex(object, method_name: nil, ignore_missing: nil, on_missing: nil, full: false, **options)
+      on_missing = Searchkick.normalize_on_missing(on_missing, ignore_missing)
       if @options[:job_options]
         options[:job_options] = (@options[:job_options] || {}).merge(options[:job_options] || {})
       end
 
       if object.is_a?(Array)
         # note: purposefully skip full
-        return reindex_records(object, method_name: method_name, ignore_missing: ignore_missing, **options)
+        return reindex_records(object, method_name: method_name, on_missing: on_missing, **options)
       end
 
       if !object.respond_to?(:searchkick_klass)
@@ -239,7 +240,7 @@ module Searchkick
         raise ArgumentError, "unsupported keywords: #{options.keys.map(&:inspect).join(", ")}" if options.any?
 
         # import only
-        import_scope(relation, method_name: method_name, mode: mode, scope: scope, ignore_missing: ignore_missing, job_options: job_options)
+        import_scope(relation, method_name: method_name, mode: mode, scope: scope, on_missing: on_missing, job_options: job_options)
         self.refresh if refresh
         true
       else
@@ -331,9 +332,21 @@ module Searchkick
       Searchkick.indexer.queue(records.reject { |r| r.id.blank? }.map { |r| RecordData.new(self, r).delete_data })
     end
 
-    def queue_update(records, method_name, ignore_missing:)
+    def queue_update(records, method_name, on_missing:)
       items = records.map { |r| RecordData.new(self, r).update_data(method_name) }
-      items.each { |i| i.instance_variable_set(:@ignore_missing, true) } if ignore_missing
+      if on_missing && on_missing != :raise
+        items.each_with_index do |item, i|
+          case on_missing
+          when :ignore
+            item.instance_variable_set(:@on_missing_ignore, true)
+          when :full
+            item.instance_variable_set(
+              :@on_missing_full_builder,
+              -> { RecordData.new(self, records[i]).index_data }
+            )
+          end
+        end
+      end
       Searchkick.indexer.queue(items)
     end
 

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -16,28 +16,49 @@ module Searchkick
     def perform
       items = @queued_items
       @queued_items = []
-
       return if items.empty?
 
       response = Searchkick.client.bulk(body: items)
+      retry_items = []
+      first_with_error = nil
+
       if response["errors"]
-        # note: delete does not set error when item not found
-        first_with_error = response["items"].map do |item|
-          (item["index"] || item["delete"] || item["update"])
-        end.find.with_index { |item, i| item["error"] && !ignore_missing?(items[i], item["error"]) }
-        if first_with_error
-          raise ImportError, "#{first_with_error["error"]} on item with id '#{first_with_error["_id"]}'"
+        response["items"].each_with_index do |resp_item, i|
+          action = resp_item["index"] || resp_item["delete"] || resp_item["update"]
+          next unless action["error"]
+
+          missing = action["error"]["type"] == "document_missing_exception"
+          full_reindex_builder = items[i].instance_variable_get(:@on_missing_full_builder)
+          ignore = items[i].instance_variable_get(:@on_missing_ignore)
+
+          if missing
+            next if ignore
+            if full_reindex_builder
+              retry_items << full_reindex_builder.call
+              next
+            end
+          end
+
+          first_with_error ||= action
         end
       end
 
-      # maybe return response in future
+      if retry_items.any?
+        # retry items are full index_data with no @on_missing_full_builder set,
+        # so they cannot trigger another retry — recursion depth is bounded at 1
+        @queued_items = retry_items
+        begin
+          perform
+        rescue ImportError => retry_error
+          raise retry_error if first_with_error.nil?
+        end
+      end
+
+      if first_with_error
+        raise ImportError, "#{first_with_error["error"]} on item with id '#{first_with_error["_id"]}'"
+      end
+
       nil
-    end
-
-    private
-
-    def ignore_missing?(item, error)
-      error["type"] == "document_missing_exception" && item.instance_variable_defined?(:@ignore_missing)
     end
   end
 end

--- a/lib/searchkick/model.rb
+++ b/lib/searchkick/model.rb
@@ -37,8 +37,8 @@ module Searchkick
       mod = Module.new
       include(mod)
       mod.module_eval do
-        def reindex(method_name = nil, mode: nil, refresh: false, ignore_missing: nil, job_options: nil)
-          self.class.searchkick_index.reindex([self], method_name: method_name, mode: mode, refresh: refresh, ignore_missing: ignore_missing, job_options: job_options, single: true)
+        def reindex(method_name = nil, mode: nil, refresh: false, ignore_missing: nil, on_missing: nil, job_options: nil)
+          self.class.searchkick_index.reindex([self], method_name: method_name, mode: mode, refresh: refresh, on_missing: on_missing, ignore_missing: ignore_missing, job_options: job_options, single: true)
         end unless base.method_defined?(:reindex)
 
         def similar(**options)

--- a/lib/searchkick/process_batch_job.rb
+++ b/lib/searchkick/process_batch_job.rb
@@ -14,7 +14,7 @@ module Searchkick
         end
 
       relation = Searchkick.scope(model)
-      RecordIndexer.new(index).reindex_items(relation, items, method_name: nil, ignore_missing: nil)
+      RecordIndexer.new(index).reindex_items(relation, items, method_name: nil, on_missing: nil)
     end
   end
 end

--- a/lib/searchkick/record_indexer.rb
+++ b/lib/searchkick/record_indexer.rb
@@ -6,7 +6,7 @@ module Searchkick
       @index = index
     end
 
-    def reindex(records, mode:, method_name:, ignore_missing:, full: false, single: false, job_options: nil)
+    def reindex(records, mode:, method_name:, on_missing:, full: false, single: false, job_options: nil)
       # prevents exists? check if records is a relation
       records = records.to_a
       return if records.empty?
@@ -21,9 +21,7 @@ module Searchkick
 
         # only add if set for backwards compatibility
         extra_options = {}
-        if ignore_missing
-          extra_options[:ignore_missing] = ignore_missing
-        end
+        extra_options[:on_missing] = on_missing.to_s if on_missing != :raise
 
         # we could likely combine ReindexV2Job, BulkReindexJob, and ProcessBatchJob
         # but keep them separate for now
@@ -61,7 +59,7 @@ module Searchkick
         index.reindex_queue.push_records(records)
       when true, :inline
         index_records, other_records = records.partition { |r| index_record?(r) }
-        import_inline(index_records, !full ? other_records : [], method_name: method_name, ignore_missing: ignore_missing, single: single)
+        import_inline(index_records, !full ? other_records : [], method_name: method_name, on_missing: on_missing, single: single)
       else
         raise ArgumentError, "Invalid value for mode"
       end
@@ -70,7 +68,7 @@ module Searchkick
       true
     end
 
-    def reindex_items(klass, items, method_name:, ignore_missing:, single: false)
+    def reindex_items(klass, items, method_name:, on_missing:, single: false)
       routing = items.to_h { |r| [r[:id], r[:routing]] }
       record_ids = routing.keys
 
@@ -86,7 +84,7 @@ module Searchkick
           construct_record(klass, id, routing[id])
         end
 
-      import_inline(records, delete_records, method_name: method_name, ignore_missing: ignore_missing, single: single)
+      import_inline(records, delete_records, method_name: method_name, on_missing: on_missing, single: single)
     end
 
     private
@@ -96,13 +94,13 @@ module Searchkick
     end
 
     # import in single request with retries
-    def import_inline(index_records, delete_records, method_name:, ignore_missing:, single:)
+    def import_inline(index_records, delete_records, method_name:, on_missing:, single:)
       return if index_records.empty? && delete_records.empty?
 
       maybe_bulk(index_records, delete_records, method_name, single) do
         if index_records.any?
           if method_name
-            index.bulk_update(index_records, method_name, ignore_missing: ignore_missing)
+            index.bulk_update(index_records, method_name, on_missing: on_missing)
           else
             index.bulk_index(index_records)
           end

--- a/lib/searchkick/reindex_v2_job.rb
+++ b/lib/searchkick/reindex_v2_job.rb
@@ -2,7 +2,8 @@ module Searchkick
   class ReindexV2Job < Searchkick.parent_job.constantize
     queue_as { Searchkick.queue_name }
 
-    def perform(class_name, id, method_name = nil, routing: nil, index_name: nil, ignore_missing: nil)
+    def perform(class_name, id, method_name = nil, routing: nil, index_name: nil, ignore_missing: nil, on_missing: nil)
+      on_missing = Searchkick.normalize_on_missing(on_missing, ignore_missing)
       model = Searchkick.load_model(class_name, allow_child: true)
       index = model.searchkick_index(name: index_name)
       # use should_index? to decide whether to index (not default scope)
@@ -11,7 +12,7 @@ module Searchkick
       # but keep for now for backwards compatibility
       model = model.unscoped if model.respond_to?(:unscoped)
       items = [{id: id, routing: routing}]
-      RecordIndexer.new(index).reindex_items(model, items, method_name: method_name, ignore_missing: ignore_missing, single: true)
+      RecordIndexer.new(index).reindex_items(model, items, method_name: method_name, on_missing: on_missing, single: true)
     end
   end
 end

--- a/lib/searchkick/relation_indexer.rb
+++ b/lib/searchkick/relation_indexer.rb
@@ -6,7 +6,7 @@ module Searchkick
       @index = index
     end
 
-    def reindex(relation, mode:, method_name: nil, ignore_missing: nil, full: false, resume: false, scope: nil, job_options: nil)
+    def reindex(relation, mode:, method_name: nil, on_missing: nil, full: false, resume: false, scope: nil, job_options: nil)
       # apply scopes
       if scope
         relation = relation.send(scope)
@@ -38,7 +38,7 @@ module Searchkick
         mode: mode,
         method_name: method_name,
         full: full,
-        ignore_missing: ignore_missing,
+        on_missing: on_missing,
         job_options: job_options
       }
       record_indexer = RecordIndexer.new(index)

--- a/test/partial_reindex_test.rb
+++ b/test/partial_reindex_test.rb
@@ -54,15 +54,15 @@ class PartialReindexTest < Minitest::Test
     assert_match "document missing", error.message
   end
 
-  def test_record_ignore_missing_inline
+  def test_record_on_missing_ignore_inline
     store [{name: "Hi", color: "Blue"}]
 
     product = Product.first
     Product.searchkick_index.remove(product)
 
-    product.reindex(:search_name, ignore_missing: true)
+    product.reindex(:search_name, on_missing: :ignore)
     Searchkick.callbacks(:bulk) do
-      product.reindex(:search_name, ignore_missing: true)
+      product.reindex(:search_name, on_missing: :ignore)
     end
   end
 
@@ -80,14 +80,14 @@ class PartialReindexTest < Minitest::Test
     end
   end
 
-  def test_record_ignore_missing_async
+  def test_record_on_missing_ignore_async
     store [{name: "Hi", color: "Blue"}]
 
     product = Product.first
     Product.searchkick_index.remove(product)
 
     perform_enqueued_jobs do
-      product.reindex(:search_name, mode: :async, ignore_missing: true)
+      product.reindex(:search_name, mode: :async, on_missing: :ignore)
     end
   end
 
@@ -146,13 +146,13 @@ class PartialReindexTest < Minitest::Test
     assert_match "document missing", error.message
   end
 
-  def test_relation_ignore_missing_inline
+  def test_relation_on_missing_ignore_inline
     store [{name: "Hi", color: "Blue"}]
 
     product = Product.first
     Product.searchkick_index.remove(product)
 
-    Product.where(id: product.id).reindex(:search_name, ignore_missing: true)
+    Product.where(id: product.id).reindex(:search_name, on_missing: :ignore)
   end
 
   def test_relation_missing_async
@@ -169,14 +169,180 @@ class PartialReindexTest < Minitest::Test
     end
   end
 
-  def test_relation_ignore_missing_async
+  def test_relation_on_missing_ignore_async
     store [{name: "Hi", color: "Blue"}]
 
     product = Product.first
     Product.searchkick_index.remove(product)
 
     perform_enqueued_jobs do
-      Product.where(id: product.id).reindex(:search_name, mode: :async, ignore_missing: true)
+      Product.where(id: product.id).reindex(:search_name, mode: :async, on_missing: :ignore)
+    end
+  end
+
+  def test_ignore_missing_deprecated
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+
+    assert_warns("ignore_missing is deprecated, use on_missing: :ignore instead") do
+      product.reindex(:search_name, ignore_missing: true)
+    end
+  end
+
+  def test_record_on_missing_raise_explicit
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+
+    error = assert_raises(Searchkick::ImportError) do
+      product.reindex(:search_name, on_missing: :raise)
+    end
+    assert_match "document missing", error.message
+  end
+
+  def test_record_on_missing_full_inline
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+    Searchkick.callbacks(false) { product.update!(name: "Bye", color: "Red") }
+
+    product.reindex(:search_name, on_missing: :full, refresh: true)
+
+    assert_search "bye", ["Bye"], fields: [:name], load: false
+    assert_search "red", ["Bye"], fields: [:color], load: false
+  end
+
+  def test_record_on_missing_full_async
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+    Searchkick.callbacks(false) { product.update!(name: "Bye", color: "Red") }
+
+    perform_enqueued_jobs do
+      product.reindex(:search_name, mode: :async, on_missing: :full)
+    end
+    Product.searchkick_index.refresh
+
+    assert_search "bye", ["Bye"], fields: [:name], load: false
+    assert_search "red", ["Bye"], fields: [:color], load: false
+  end
+
+  def test_relation_on_missing_full_inline
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+    Searchkick.callbacks(false) { product.update!(name: "Bye", color: "Red") }
+
+    Product.where(id: product.id).reindex(:search_name, on_missing: :full)
+    Product.searchkick_index.refresh
+
+    assert_search "bye", ["Bye"], fields: [:name], load: false
+    assert_search "red", ["Bye"], fields: [:color], load: false
+  end
+
+  def test_relation_on_missing_full_async
+    store [{name: "Hi", color: "Blue"}]
+    product = Product.first
+    Product.searchkick_index.remove(product)
+    Searchkick.callbacks(false) { product.update!(name: "Bye", color: "Red") }
+
+    perform_enqueued_jobs do
+      Product.where(id: product.id).reindex(:search_name, mode: :async, on_missing: :full)
+    end
+    Product.searchkick_index.refresh
+
+    assert_search "bye", ["Bye"], fields: [:name], load: false
+    assert_search "red", ["Bye"], fields: [:color], load: false
+  end
+
+  def test_on_missing_full_mixed_batch
+    store [{name: "Present", color: "Blue"}, {name: "Missing", color: "Blue"}]
+    present = Product.find_by!(name: "Present")
+    missing = Product.find_by!(name: "Missing")
+
+    Product.searchkick_index.remove(missing)
+    Searchkick.callbacks(false) do
+      present.update!(name: "PresentUpdated", color: "Red")
+      missing.update!(name: "MissingUpdated", color: "Red")
+    end
+
+    Product.where(id: [present.id, missing.id]).reindex(:search_name, on_missing: :full)
+    Product.searchkick_index.refresh
+
+    assert_search "presentupdated", ["PresentUpdated"], fields: [:name], load: false
+    assert_search "missingupdated", ["MissingUpdated"], fields: [:name], load: false
+
+    assert_search "blue", ["PresentUpdated"], fields: [:color], load: false
+
+    assert_search "red", ["MissingUpdated"], fields: [:color], load: false
+  end
+
+  def test_on_missing_full_mixed_with_other_error
+    store [
+      {name: "Present", color: "Blue"},
+      {name: "Missing", color: "Blue"},
+      {name: "Error",   color: "Blue"}
+    ]
+    present_product = Product.find_by!(name: "Present")
+    missing_product = Product.find_by!(name: "Missing")
+    error_product     = Product.find_by!(name: "Error")
+
+    Product.searchkick_index.remove(missing_product)
+
+    Searchkick.callbacks(false) do
+      present_product.update!(name: "PresentUpdated", color: "Red")
+      missing_product.update!(name: "MissingUpdated", color: "Red")
+      error_product.update!(name: "ErrorUpdated", color: "Red")
+    end
+
+    # ES will reject with mapper_parsing_exception
+    Product.class_eval do
+      alias_method :__orig_search_name, :search_name
+      define_method(:search_name) do
+        self.name == "ErrorUpdated" ? {name: {nested: "x"}} : __orig_search_name
+      end
+    end
+
+    error = assert_raises(Searchkick::ImportError) do
+      Product.where(id: [present_product.id, missing_product.id, error_product.id])
+        .reindex(:search_name, on_missing: :full)
+    end
+    
+    refute_match "document_missing", error.message
+    assert_match(/mapper|parsing|illegal/i, error.message)
+
+    Product.searchkick_index.refresh
+
+    assert_search "missingupdated", ["MissingUpdated"], fields: [:name], load: false
+    assert_search "red",            ["MissingUpdated"], fields: [:color], load: false
+  ensure
+    Product.class_eval do
+      alias_method :search_name, :__orig_search_name
+      remove_method :__orig_search_name
+    end
+  end
+
+  def test_on_missing_invalid_value
+    product = Product.create!(name: "Hi")
+    error = assert_raises(ArgumentError) do
+      product.reindex(:search_name, on_missing: :ful)
+    end
+    assert_match "on_missing", error.message
+    assert_match ":raise", error.message
+  end
+
+  def test_on_missing_and_ignore_missing_conflict
+    product = Product.create!(name: "Hi")
+    assert_raises(ArgumentError) do
+      product.reindex(:search_name, on_missing: :ignore, ignore_missing: true)
+    end
+  end
+
+  def test_on_missing_and_ignore_missing_false_conflict
+    product = Product.create!(name: "Hi")
+    assert_raises(ArgumentError) do
+      product.reindex(:search_name, on_missing: :raise, ignore_missing: false)
     end
   end
 end


### PR DESCRIPTION
Introduces a new on_missing: :raise | :ignore | :full option across partial reindex flows (record, relation, and async jobs), replacing ignore_missing while keeping it as a deprecated shim via Searchkick.normalize_on_missing (validation + conflict checks + warnings).

Adds :full semantics for partial updates: when a bulk update fails with document_missing_exception, Searchkick can re-queue that document as a full index operation (one bounded retry) instead of raising immediately.
