### PR TITLE
Add batch_size: option to Searchkick.callbacks(:bulk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,14 @@ Searchkick.callbacks(:bulk) do
 end
 ```
 
+To avoid large `_bulk` requests when processing many records, use `batch_size:` to flush automatically after every N items.
+
+```ruby
+Searchkick.callbacks(:bulk, batch_size: 1000) do
+  Product.find_each(&:update_fields)
+end
+```
+
 Or temporarily skip updates.
 
 ```ruby

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -214,11 +214,13 @@ module Searchkick
   end
 
   # message is private
-  def self.callbacks(value = nil, message: nil)
+  def self.callbacks(value = nil, batch_size: nil, message: nil)
     if block_given?
       previous_value = callbacks_value
+      previous_batch_size = bulk_batch_size
       begin
         self.callbacks_value = value
+        Thread.current[:searchkick_bulk_batch_size] = batch_size if value == :bulk
         result = yield
         if callbacks_value == :bulk && indexer.queued_items.any?
           event = {}
@@ -235,10 +237,15 @@ module Searchkick
         result
       ensure
         self.callbacks_value = previous_value
+        Thread.current[:searchkick_bulk_batch_size] = previous_batch_size
       end
     else
       self.callbacks_value = value
     end
+  end
+
+  def self.bulk_batch_size
+    Thread.current[:searchkick_bulk_batch_size]
   end
 
   def self.aws_credentials=(creds)

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -220,24 +220,41 @@ module Searchkick
       previous_batch_size = bulk_batch_size
       begin
         self.callbacks_value = value
-        Thread.current[:searchkick_bulk_batch_size] = batch_size if value == :bulk
+        self.bulk_batch_size = batch_size if value == :bulk
         result = yield
         if callbacks_value == :bulk && indexer.queued_items.any?
-          event = {}
-          if message
-            message.call(event)
+          size = bulk_batch_size
+          if size
+            indexer.queued_items.each_slice(size) do |slice|
+              event = {}
+              if message
+                message.call(event)
+              else
+                event[:name] = "Bulk"
+                event[:count] = slice.size
+              end
+              ActiveSupport::Notifications.instrument("request.searchkick", event) do
+                indexer.perform_items(slice)
+              end
+            end
+            indexer.queued_items.clear
           else
-            event[:name] = "Bulk"
-            event[:count] = indexer.queued_items.size
-          end
-          ActiveSupport::Notifications.instrument("request.searchkick", event) do
-            indexer.perform
+            event = {}
+            if message
+              message.call(event)
+            else
+              event[:name] = "Bulk"
+              event[:count] = indexer.queued_items.size
+            end
+            ActiveSupport::Notifications.instrument("request.searchkick", event) do
+              indexer.perform
+            end
           end
         end
         result
       ensure
         self.callbacks_value = previous_value
-        Thread.current[:searchkick_bulk_batch_size] = previous_batch_size
+        self.bulk_batch_size = previous_batch_size
       end
     else
       self.callbacks_value = value
@@ -246,6 +263,10 @@ module Searchkick
 
   def self.bulk_batch_size
     Thread.current[:searchkick_bulk_batch_size]
+  end
+
+  def self.bulk_batch_size=(value)
+    Thread.current[:searchkick_bulk_batch_size] = value
   end
 
   def self.aws_credentials=(creds)

--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -223,32 +223,15 @@ module Searchkick
         self.bulk_batch_size = batch_size if value == :bulk
         result = yield
         if callbacks_value == :bulk && indexer.queued_items.any?
-          size = bulk_batch_size
-          if size
-            indexer.queued_items.each_slice(size) do |slice|
-              event = {}
-              if message
-                message.call(event)
-              else
-                event[:name] = "Bulk"
-                event[:count] = slice.size
-              end
-              ActiveSupport::Notifications.instrument("request.searchkick", event) do
-                indexer.perform_items(slice)
-              end
-            end
-            indexer.queued_items.clear
+          event = {}
+          if message
+            message.call(event)
           else
-            event = {}
-            if message
-              message.call(event)
-            else
-              event[:name] = "Bulk"
-              event[:count] = indexer.queued_items.size
-            end
-            ActiveSupport::Notifications.instrument("request.searchkick", event) do
-              indexer.perform
-            end
+            event[:name] = "Bulk"
+            event[:count] = indexer.queued_items.size
+          end
+          ActiveSupport::Notifications.instrument("request.searchkick", event) do
+            indexer.perform(batch_size: bulk_batch_size)
           end
         end
         result

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -10,12 +10,7 @@ module Searchkick
 
     def queue(items)
       @queued_items.concat(items)
-      if Searchkick.callbacks_value == :bulk
-        batch_size = Searchkick.bulk_batch_size
-        perform if batch_size && @queued_items.size >= batch_size
-      else
-        perform
-      end
+      perform unless Searchkick.callbacks_value == :bulk
     end
 
     def perform
@@ -24,6 +19,15 @@ module Searchkick
 
       return if items.empty?
 
+      bulk(items)
+    end
+
+    def perform_items(items)
+      @queued_items = items
+      perform
+    end
+
+    def bulk(items)
       response = Searchkick.client.bulk(body: items)
       if response["errors"]
         # note: delete does not set error when item not found

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -10,7 +10,12 @@ module Searchkick
 
     def queue(items)
       @queued_items.concat(items)
-      perform unless Searchkick.callbacks_value == :bulk
+      if Searchkick.callbacks_value == :bulk
+        batch_size = Searchkick.bulk_batch_size
+        perform if batch_size && @queued_items.size >= batch_size
+      else
+        perform
+      end
     end
 
     def perform

--- a/lib/searchkick/indexer.rb
+++ b/lib/searchkick/indexer.rb
@@ -13,18 +13,17 @@ module Searchkick
       perform unless Searchkick.callbacks_value == :bulk
     end
 
-    def perform
+    def perform(batch_size: nil)
       items = @queued_items
       @queued_items = []
 
       return if items.empty?
 
-      bulk(items)
-    end
-
-    def perform_items(items)
-      @queued_items = items
-      perform
+      if batch_size
+        items.each_slice(batch_size) { |slice| bulk(slice) }
+      else
+        bulk(items)
+      end
     end
 
     def bulk(items)

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -113,10 +113,9 @@ class CallbacksTest < Minitest::Test
     assert_nil Searchkick.bulk_batch_size, "batch_size should be nil after all blocks exit"
   end
 
-  def test_bulk_batch_size_exception_preserves_flushed_items
-    # Use batch_size: 1 so each item flushes immediately — makes exception timing deterministic
+  def test_bulk_batch_size_exception_nothing_flushed
     begin
-      Searchkick.callbacks(:bulk, batch_size: 1) do
+      Searchkick.callbacks(:bulk, batch_size: 2) do
         store_names ["Safe A", "Safe B"]
         raise "intentional error"
       end
@@ -124,7 +123,25 @@ class CallbacksTest < Minitest::Test
       # expected
     end
     Product.searchkick_index.refresh
-    assert_search "safe", ["Safe A", "Safe B"]
+    assert_search "safe", []
+  end
+
+  def test_bulk_batch_size_fires_instrumentation_per_batch
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe("request.searchkick") do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      events << event.payload[:count]
+    end
+
+    Searchkick.callbacks(:bulk, batch_size: 2) do
+      store_names (1..5).map { |i| "InstrProduct #{i}" }
+    end
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    # 5 items with batch_size 2 → 3 batches (2, 2, 1)
+    assert_equal 3, events.size
+    assert_equal [2, 2, 1], events
   end
 
   def test_disable_callbacks

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -126,22 +126,25 @@ class CallbacksTest < Minitest::Test
     assert_search "safe", []
   end
 
-  def test_bulk_batch_size_fires_instrumentation_per_batch
-    events = []
-    subscription = ActiveSupport::Notifications.subscribe("request.searchkick") do |*args|
-      event = ActiveSupport::Notifications::Event.new(*args)
-      events << event.payload[:count]
+  def test_bulk_batch_size_makes_n_http_calls
+    bulk_call_count = 0
+    original_bulk = Searchkick::Indexer.instance_method(:bulk)
+
+    Searchkick::Indexer.define_method(:bulk) do |items|
+      bulk_call_count += 1
+      original_bulk.bind(self).call(items)
     end
 
-    Searchkick.callbacks(:bulk, batch_size: 2) do
-      store_names (1..5).map { |i| "InstrProduct #{i}" }
+    begin
+      Searchkick.callbacks(:bulk, batch_size: 2) do
+        store_names (1..5).map { |i| "HttpProduct #{i}" }
+      end
+    ensure
+      Searchkick::Indexer.define_method(:bulk, original_bulk)
     end
 
-    ActiveSupport::Notifications.unsubscribe(subscription)
-
-    # 5 items with batch_size 2 → 3 batches (2, 2, 1)
-    assert_equal 3, events.size
-    assert_equal [2, 2, 1], events
+    # 5 items with batch_size 2 → 3 HTTP calls (2, 2, 1)
+    assert_equal 3, bulk_call_count
   end
 
   def test_disable_callbacks

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -84,6 +84,49 @@ class CallbacksTest < Minitest::Test
     end
   end
 
+  def test_bulk_batch_size_all_items_indexed
+    names = (1..5).map { |i| "BatchProduct #{i}" }
+    Searchkick.callbacks(:bulk, batch_size: 2) do
+      store_names names
+    end
+    Product.searchkick_index.refresh
+    assert_search "batchproduct", names
+  end
+
+  def test_bulk_batch_size_remainder_flushed_at_block_end
+    Searchkick.callbacks(:bulk, batch_size: 3) do
+      store_names ["Rem A", "Rem B"]
+    end
+    Product.searchkick_index.refresh
+    assert_search "rem", ["Rem A", "Rem B"]
+  end
+
+  def test_bulk_batch_size_nesting_restores_outer_threshold
+    outer_batch_size_during_inner = nil
+    Searchkick.callbacks(:bulk, batch_size: 100) do
+      Searchkick.callbacks(:bulk, batch_size: 50) do
+        outer_batch_size_during_inner = Searchkick.bulk_batch_size
+      end
+      assert_equal 100, Searchkick.bulk_batch_size, "outer batch_size should be restored after inner block"
+    end
+    assert_equal 50, outer_batch_size_during_inner
+    assert_nil Searchkick.bulk_batch_size, "batch_size should be nil after all blocks exit"
+  end
+
+  def test_bulk_batch_size_exception_preserves_flushed_items
+    # Use batch_size: 1 so each item flushes immediately — makes exception timing deterministic
+    begin
+      Searchkick.callbacks(:bulk, batch_size: 1) do
+        store_names ["Safe A", "Safe B"]
+        raise "intentional error"
+      end
+    rescue RuntimeError
+      # expected
+    end
+    Product.searchkick_index.refresh
+    assert_search "safe", ["Safe A", "Safe B"]
+  end
+
   def test_disable_callbacks
     # make sure callbacks default to on
     assert Searchkick.callbacks?


### PR DESCRIPTION
## Motivation

When indexing large numbers of records in a `:bulk` callbacks block, a single `_bulk` request can exhaust connection pools or exceed request size limits (OpenSearch/Elasticsearch returns 413). The current workaround is manual `each_slice` outside the block.

## Changes

New `batch_size:` keyword argument on `Searchkick.callbacks(:bulk)` splits accumulated items into bounded chunks, each sent as a separate `_bulk` request **at the end of the block** (not mid-block).

```ruby
Searchkick.callbacks(:bulk, batch_size: 1000) do
  Product.find_each(&:update_fields)
end
```

Key behaviors:

- Items accumulate during the block (no mid-block flush)
- At block end, `Indexer#perform(batch_size:)` slices items internally; each slice sent as own `_bulk` request
- Single `ActiveSupport::Notifications` instrument event wraps all batched HTTP calls (count reflects total items)
- Exception inside block → nothing flushed (clean failure, no partial state)
- Default (no `batch_size:`) → single flush as before, unchanged
- `Searchkick.bulk_batch_size=` setter added, mirroring `callbacks_value=` pattern
- Thread-local state; nested blocks restore outer `batch_size` on exit

## Tests

- All items indexed across batches
- Remainder (items < batch_size) flushed at block end
- Nesting restores outer `batch_size`
- Exception leaves nothing indexed
- N HTTP calls made when batch_size set (5 items / batch_size 2 → 3 `bulk` calls)

## Naming

Used `batch_size:` to match the existing convention in `RelationIndexer`.