### PR TITLE
Fix clear_scroll failing with too_long_http_line_exception on indices with many shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed `clear_scroll` failing with `too_long_http_line_exception` on indices with many shards (scroll_id moved to request body)
+
 ## 6.1.1 (2026-05-14)
 
 - Fixed smart aggs behavior with `_and`

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -208,7 +208,7 @@ module Searchkick
         # try to clear scroll
         # not required as scroll will expire
         # but there is a cost to open scrolls
-        Searchkick.client.clear_scroll(scroll_id: scroll_id)
+        Searchkick.client.clear_scroll(body: {scroll_id: scroll_id})
       rescue => e
         raise e unless Searchkick.transport_error?(e)
       end


### PR DESCRIPTION
## What

Fixes `clear_scroll` failing with `too_long_http_line_exception` on OpenSearch/Elasticsearch indices with many shards.

## Problem

`Searchkick::Results#clear_scroll` (line 211 of `lib/searchkick/results.rb`) passes `scroll_id` as a URL query parameter:

```ruby
Searchkick.client.clear_scroll(scroll_id: scroll_id)
```

OpenSearch and Elasticsearch encode a search context pointer for each shard inside the `scroll_id`. On indices with many shards (e.g., 160 primaries), the encoded scroll_id exceeds 10KB and hits AWS managed OpenSearch's `http.max_initial_line_length` limit of 10,240 bytes:

```
[400] {"error":{"root_cause":[{"type":"too_long_http_line_exception","reason":"An HTTP line is larger than 10240 bytes."}]}}
```

This breaks any code path that calls `clear_scroll` after a sliced search/export job on large indices.

## Fix

Send `scroll_id` in the request body instead of the URL — the body has no equivalent size limit.

```diff
- Searchkick.client.clear_scroll(scroll_id: scroll_id)
+ Searchkick.client.clear_scroll(body: {scroll_id: scroll_id})
```

This is also a consistency fix: the `scroll` method on [line 192](https://github.com/ankane/searchkick/blob/master/lib/searchkick/results.rb#L192) of the same file already uses the body form correctly. Only `clear_scroll` was the outlier.

## Best practices followed

- **Official API documentation** — Both [Elasticsearch's Clear Scroll API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-clear-scroll) and [OpenSearch's Scroll documentation](https://opensearch.org/docs/latest/api-reference/scroll/) document the request-body form (`{ "scroll_id": "..." }`) as the canonical way to pass scroll IDs.
- **Consistency with existing code** — Matches the body-based pattern already used by `Searchkick::Results#scroll` (line 192).

## Testing

Tested against a production OpenSearch 3.3 cluster with a 160-shard index:
- **Before fix:** `clear_scroll` raises `Elasticsearch::Transport::Transport::Errors::BadRequest: too_long_http_line_exception`
- **After fix:** `clear_scroll` succeeds; scrolls complete cleanly with no errors

